### PR TITLE
制御タスクを Core 1 へ移動し platform バージョンを固定

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:m5stack-core2]
-platform = espressif32
+platform = espressif32@6.10.0
 board = m5stack-core2
 framework = arduino
 monitor_speed = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,13 +272,13 @@ void setup(){
   
   // RTOS Task Settings
   const uint32_t MEMORY_STACK = 8192;
-  const UBaseType_t PRIORIRY_SPIN_MAIN = 5;
-  const BaseType_t ID_CORE_CTRL_MAIN = 0;
-  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORIRY_SPIN_MAIN, NULL, ID_CORE_CTRL_MAIN);
-  
-  const UBaseType_t PRIORIRY_SPIN_SUB = 2;
-  const BaseType_t ID_CORE_CTRL_SUB = 1;
-  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORIRY_SPIN_SUB,  NULL, ID_CORE_CTRL_SUB);
+  const UBaseType_t PRIORITY_CTRL = 20;
+  const BaseType_t CORE_CTRL = 1;
+  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORITY_CTRL, NULL, CORE_CTRL);
+
+  const UBaseType_t PRIORITY_UI = 3;
+  const BaseType_t CORE_UI = 0;
+  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORITY_UI,   NULL, CORE_UI);
 }
 
 


### PR DESCRIPTION
## Summary
- 制御ループタスクを Core 0（WiFi コア）→ Core 1（アプリケーションコア）へ移動、優先度を 5→20 に引き上げ
- UI タスクを Core 1→ Core 0 へ移動、優先度を 2→3 に調整
- `espressif32@6.10.0` にバージョン固定しビルド再現性を確保

## Test plan
- [x] `pio run` ビルド成功
- [x] 実機書き込み・起動クラッシュなし
- [x] バランス動作が従来と同等
- [x] タッチ UI 正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)