### PR TITLE
I2C mutex + IMU バースト読み + 選択的初期化 + Avatar 無効化

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,6 @@
 #include <Arduino.h>
 
 #include <M5Unified.h>
-#include <Avatar.h>
-
-#include "TairinEye.h"
-#include "TairinMouth.h"
 
 #include <Kalman.h>
 #include <Preferences.h>
@@ -15,28 +11,11 @@ HardwareSerial& DXL_SERIAL = Serial1;
 #define DEBUG_SERIAL Serial
 //#define ENABLE_DEBUG_PRINT
 
-
-using namespace m5avatar;
-Avatar avatar;
-Face* tairinFace;
-
-Face* createTairinFace(){
-  Face* f;
-  f = new Face(
-    new tairinMouth(50, 90, 4, 60),
-    new tairinEye(8, false),
-    new tairinEye(8, true),
-    new Eyeblow(32, 0, false),
-    new Eyeblow(32, 0, true)
-  );
-  return f;
-}
-
 // M5Stack Core2 PORT A pin configuration
 const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
-// Contoller Params. 
+// Contoller Params.
 const TickType_t xPeriodMs = 10;  // [milli sec]
 float Kp = 50.0;
 float Ki = 1.0;
@@ -51,8 +30,6 @@ float preP = 0.0;
 
 // Kalman filter Params.
 Kalman kalman;
-float accX, accY, accZ;
-float gyroX, gyroY, gyroZ;
 
 // Contoller Values
 unsigned long previousTimestamp = 0;
@@ -66,18 +43,22 @@ const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl;//(DXL_SERIAL);
 
+// I2C bus mutex (IMU on control task vs AXP192/touch on UI task)
+SemaphoreHandle_t g_i2c_mutex = nullptr;
 
-float getPitch(){
-  M5.Imu.getAccelData(&accX, &accY, &accZ);
-  float pitch = atan2(accY, accZ) * RAD_TO_DEG; //[deg]
-  return pitch;
-}
+struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
 
-
-float getPitchDot() {
-  M5.Imu.getGyroData(&gyroX, &gyroY, &gyroZ);
-  float pitch_dot = gyroX;
-  return pitch_dot;  //[deg/sec]
+ImuData readImuBurst() {
+    ImuData r = {0, 0, false};
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) return r;
+    auto mask = M5.Imu.update();
+    xSemaphoreGive(g_i2c_mutex);
+    if (!mask) return r;
+    auto d = M5.Imu.getImuData();
+    r.pitch_deg = atan2f(d.accel.y, d.accel.z) * RAD_TO_DEG;
+    r.pitch_rate_dps = d.gyro.x;
+    r.valid = true;
+    return r;
 }
 
 
@@ -101,9 +82,13 @@ void calcPID(){
   currentTimestamp = micros();
   elapsedTime = currentTimestamp - previousTimestamp;
   previousTimestamp = currentTimestamp;
-  
+
   float dt = (float)xPeriodMs /1000; // [sec]
-  float pitch_kalman = kalman.getAngle(getPitch(), getPitchDot(), dt);
+
+  ImuData imu = readImuBurst();
+  if (!imu.valid) return;
+
+  float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
   float pitch_dot_kalman = kalman.getRate();
 
   float pitch_error = pitch_target - pitch_kalman;
@@ -125,7 +110,7 @@ void calcPID(){
   if (200 < abs(I * Ki)) {
     I = 0;
   }
-    
+
   // Calclate Motor Output
   int rpm_motor = Kp * P + Ki * I + Kd * D;
   rpm_motor = constrain(rpm_motor, -300, 300);
@@ -140,7 +125,7 @@ void drawButton(const char* label, int x, int y, float value) {
 
   M5.Display.drawRect(x+200, y, 50, 30, WHITE);
   M5.Display.drawString("+", x+200+20, y, 2);
-  
+
   // draw label and value
   M5.Display.setCursor(x+70, y+5);
   M5.Display.print(label);
@@ -155,9 +140,12 @@ void drawCtrlPanel(){
   drawButton("Ki", 20, 110, Ki);
   drawButton("Kd", 20, 150, Kd);
 
-  M5.Display.setCursor(20, 190);
-  int batteryPercentage = M5.Power.getBatteryLevel();
-  M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+  if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    int batteryPercentage = M5.Power.getBatteryLevel();
+    xSemaphoreGive(g_i2c_mutex);
+    M5.Display.setCursor(20, 190);
+    M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+  }
 }
 
 
@@ -202,30 +190,26 @@ void controlLoopTask(void *pvParameters) {
 
 bool enShowCtrlPanel = false;
 void uiLoopTask(void *pvParameters){
-  
-  TickType_t xLastWakeTime = xTaskGetTickCount();  
-  while(true){
-    M5.update();
 
-    //draw avatar face
-    if (M5.BtnA.wasPressed()) {
-      avatar.resume();
+  TickType_t xLastWakeTime = xTaskGetTickCount();
+  while(true){
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+      M5.update();
+      xSemaphoreGive(g_i2c_mutex);
     }
 
     // show tuning panel
     if (M5.BtnB.wasPressed()) {
       if (enShowCtrlPanel) {
         enShowCtrlPanel = false;
-        avatar.resume();
         M5.Lcd.clear();
       } else {
         enShowCtrlPanel = true;
-        avatar.suspend();
         M5.Lcd.clear();
         drawCtrlPanel();
       }
     }
-    
+
     if (enShowCtrlPanel) {
       bool isReleased = true;
         if (M5.Touch.getCount()>0 && isReleased) {
@@ -242,19 +226,23 @@ void setup(){
 
   DEBUG_SERIAL.begin(115200);
 
-  // M5 Settings
-  M5.begin();
+  // M5 Settings (selective init: disable unused peripherals)
+  auto cfg = M5.config();
+  cfg.internal_rtc = false;
+  cfg.internal_mic = false;
+  cfg.internal_spk = false;
+  cfg.internal_imu = true;
+  M5.begin(cfg);
   M5.Lcd.fillScreen(BLACK);
   M5.Lcd.setTextSize(2);
   M5.Lcd.setCursor(0, 0);
-  M5.Imu.init();
-  // M5.Imu.setAccelFsr(M5.Imu.AFS_2G);
-  // M5.Imu.setGyroFsr(M5.Imu.GFS_250DPS);
 
-  // M5 avatar Settings
-  tairinFace = createTairinFace();
-  avatar.setFace(tairinFace);
-  avatar.init();
+  // Avatar disabled during architecture improvement (Phase 3-8)
+  // Will be re-enabled in Phase 9 after all improvements are stable.
+
+  // I2C mutex
+  g_i2c_mutex = xSemaphoreCreateMutex();
+  configASSERT(g_i2c_mutex != nullptr);
 
   // DYNAMIXEL Settings
   DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
@@ -264,17 +252,22 @@ void setup(){
   dxl.ping(DXL_ID_L);
   dxl.ping(DXL_ID_R);
   dxl.torqueOff(DXL_ID_L);  // Turn off torque when configuring items in EEPROM area
-  dxl.torqueOff(DXL_ID_R); 
+  dxl.torqueOff(DXL_ID_R);
   dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
   dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
   dxl.torqueOn(DXL_ID_L);
   dxl.torqueOn(DXL_ID_R);
 
-  // Kalman filter Setting
-  kalman.setAngle(getPitch());
-  
-  // WDT: I2C ハング等で制御ループが停止した場合にシステムリセット
-  esp_task_wdt_init(1, true);  // 1秒タイムアウト、panic=true
+  // Kalman filter Setting (initial pitch via burst read)
+  ImuData imu_init = readImuBurst();
+  if (imu_init.valid) {
+    kalman.setAngle(imu_init.pitch_deg);
+  } else {
+    kalman.setAngle(86.0);
+  }
+
+  // WDT
+  esp_task_wdt_init(1, true);
 
   // RTOS Task Settings
   const uint32_t MEMORY_STACK = 8192;
@@ -289,5 +282,5 @@ void setup(){
 
 
 void loop(){
-  
+
 }


### PR DESCRIPTION
## Summary
- I2C バス排他制御: `xSemaphoreCreateMutex` で IMU 読み出し（制御タスク）と `M5.update()`/`getBatteryLevel()`（UI タスク）を mutex 保護
- IMU バースト読み: `getPitch()`+`getPitchDot()` の分割 I2C 読みを `M5.Imu.update()` 14byte 一括読みに置換（accel/gyro の時間整合性改善）
- 選択的 `M5.begin(cfg)`: RTC/MIC/SPK を無効化、冗長な `M5.Imu.init()` を削除
- Avatar 無効化: `avatar.init()` を停止し描画タスクによる CPU/SPI 消費を排除（Phase 9 で復帰予定）

## Test plan
- [x] `pio run` ビルド成功（RAM/Flash 削減確認）
- [x] 実機書き込み・起動クラッシュなし
- [x] バランス動作デグレなし
- [x] BtnB → チューニングパネル → タッチ操作正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)