### PR TITLE
スレッド安全性・実測 dt・anti-windup・テレメトリキュー・タッチ修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,45 +6,52 @@
 #include <Preferences.h>
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
+#include <esp_timer.h>
 
 HardwareSerial& DXL_SERIAL = Serial1;
-#define DEBUG_SERIAL Serial
-//#define ENABLE_DEBUG_PRINT
 
 // M5Stack Core2 PORT A pin configuration
 const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
-// Contoller Params.
-const TickType_t xPeriodMs = 10;  // [milli sec]
-float Kp = 50.0;
-float Ki = 1.0;
-float Kd = 1.0;
-
-float pitch_target = 86.0; //[deg]
-
-float P = 0.0;
-float I = 0.0;
-float D = 0.0;
-float preP = 0.0;
-
-// Kalman filter Params.
-Kalman kalman;
-
-// Contoller Values
-unsigned long previousTimestamp = 0;
-unsigned long currentTimestamp = 0;
-unsigned long elapsedTime = 0;
+// Default controller params
+const float DEFAULT_KP = 50.0f;
+const float DEFAULT_KI = 1.0f;
+const float DEFAULT_KD = 1.0f;
+const float DEFAULT_PITCH_TARGET = 86.0f;
+const TickType_t xPeriodMs = 10;
 
 // DYNAMIXEL Params.
 const uint8_t DXL_ID_L = 0;
 const uint8_t DXL_ID_R = 1;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
-Dynamixel2Arduino dxl;//(DXL_SERIAL);
+Dynamixel2Arduino dxl;
+Kalman kalman;
 
-// I2C bus mutex (IMU on control task vs AXP192/touch on UI task)
+// I2C bus mutex
 SemaphoreHandle_t g_i2c_mutex = nullptr;
+
+// --- Inter-task communication ---
+
+enum class CtrlCommandType : uint8_t {
+    SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
+};
+struct CtrlCommand { CtrlCommandType type; float value; };
+
+struct TelemetryData {
+    float pitch_deg;
+    float pitch_rate_dps;
+    float rpm_cmd;
+    float P_term, I_term, D_term;
+    uint32_t loop_us;
+    bool fallen;
+};
+
+QueueHandle_t g_cmd_queue = nullptr;
+QueueHandle_t g_telemetry_queue = nullptr;
+
+// --- IMU burst read ---
 
 struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
 
@@ -61,226 +68,259 @@ ImuData readImuBurst() {
     return r;
 }
 
+// --- Motor drive ---
 
 void driveTire(int rpm) {
-
-  // Set Goal Velocity using RPM
-  dxl.setGoalVelocity(DXL_ID_L, -1*rpm, UNIT_RPM);
-  dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
-
-  #ifdef ENABLE_DEBUG_PRINT
-  DEBUG_SERIAL.print("Present Velocity(rpm)--L : ");
-  DEBUG_SERIAL.print(dxl.getPresentVelocity(DXL_ID_L, UNIT_RPM));
-  DEBUG_SERIAL.print(", R : ");
-  DEBUG_SERIAL.println(dxl.getPresentVelocity(DXL_ID_R, UNIT_RPM));
-  #endif
+    dxl.setGoalVelocity(DXL_ID_L, -1 * rpm, UNIT_RPM);
+    dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
 }
 
-
-void calcPID(){
-
-  currentTimestamp = micros();
-  elapsedTime = currentTimestamp - previousTimestamp;
-  previousTimestamp = currentTimestamp;
-
-  float dt = (float)xPeriodMs /1000; // [sec]
-
-  ImuData imu = readImuBurst();
-  if (!imu.valid) return;
-
-  float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
-  float pitch_dot_kalman = kalman.getRate();
-
-  float pitch_error = pitch_target - pitch_kalman;
-
-  if(pitch_error < -40 || 40 < pitch_error) {
-    driveTire(0);
-    P = 0;
-    I = 0;
-    D = 0;
-    return;
-  }
-
-  P = pitch_target - pitch_kalman;
-  I += P * dt;
-  D = (P - preP) / dt;
-  preP = P;
-
-  // anti windup
-  if (200 < abs(I * Ki)) {
-    I = 0;
-  }
-
-  // Calclate Motor Output
-  int rpm_motor = Kp * P + Ki * I + Kd * D;
-  rpm_motor = constrain(rpm_motor, -300, 300);
-  driveTire(rpm_motor);
-}
-
-
-void drawButton(const char* label, int x, int y, float value) {
-  // draw button
-  M5.Display.drawRect(x, y, 50, 30, WHITE);
-  M5.Display.drawString("-", x+20, y, 2);
-
-  M5.Display.drawRect(x+200, y, 50, 30, WHITE);
-  M5.Display.drawString("+", x+200+20, y, 2);
-
-  // draw label and value
-  M5.Display.setCursor(x+70, y+5);
-  M5.Display.print(label);
-  M5.Display.print(": ");
-  M5.Display.println(value, 1);
-}
-
-
-void drawCtrlPanel(){
-  drawButton("Ref", 20, 30, pitch_target);
-  drawButton("Kp", 20, 70, Kp);
-  drawButton("Ki", 20, 110, Ki);
-  drawButton("Kd", 20, 150, Kd);
-
-  if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-    int batteryPercentage = M5.Power.getBatteryLevel();
-    xSemaphoreGive(g_i2c_mutex);
-    M5.Display.setCursor(20, 190);
-    M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
-  }
-}
-
-
-void handleCtrlPanelTouched(){
-
-  auto pos = M5.Touch.getDetail();
-
-  if (pos.y >= 30 && pos.y < 60) { // Target
-    if (pos.x >= 15 && pos.x < 120) pitch_target -= 0.2;
-      else if (pos.x >= 220 && pos.x < 270) pitch_target += 0.2;
-      drawButton("Ref", 20, 30, pitch_target);
-  }
-  else if (pos.y >= 70 && pos.y < 100) {
-    if (pos.x >= 15 && pos.x < 120) Kp -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Kp += 0.2;
-    drawButton("Kp", 20, 70, Kp);
-  }
-  else if (pos.y >= 110 && pos.y < 140) { // Ki
-    if (pos.x >= 15 && pos.x < 120) Ki -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Ki += 0.2;
-    drawButton("Ki", 20, 110, Ki);
-  }
-  else if (pos.y >= 150 && pos.y < 180) { // Kd
-    if (pos.x >= 15 && pos.x < 120) Kd -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Kd += 0.2;
-    drawButton("Kd", 20, 150, Kd);
-  }
-}
-
+// --- Control task ---
 
 void controlLoopTask(void *pvParameters) {
     esp_task_wdt_add(NULL);
     TickType_t xLastWakeTime = xTaskGetTickCount();
 
-    while(true) {
-      esp_task_wdt_reset();
-      calcPID();
-      vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
-    }
-}
+    float kp = DEFAULT_KP;
+    float ki = DEFAULT_KI;
+    float kd = DEFAULT_KD;
+    float target = DEFAULT_PITCH_TARGET;
+    float I_acc = 0.0f;
+    float preP = 0.0f;
+    int64_t prev_us = 0;
 
+    while (true) {
+        esp_task_wdt_reset();
+        int64_t now_us = esp_timer_get_time();
 
-bool enShowCtrlPanel = false;
-void uiLoopTask(void *pvParameters){
-
-  TickType_t xLastWakeTime = xTaskGetTickCount();
-  while(true){
-    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-      M5.update();
-      xSemaphoreGive(g_i2c_mutex);
-    }
-
-    // show tuning panel
-    if (M5.BtnB.wasPressed()) {
-      if (enShowCtrlPanel) {
-        enShowCtrlPanel = false;
-        M5.Lcd.clear();
-      } else {
-        enShowCtrlPanel = true;
-        M5.Lcd.clear();
-        drawCtrlPanel();
-      }
-    }
-
-    if (enShowCtrlPanel) {
-      bool isReleased = true;
-        if (M5.Touch.getCount()>0 && isReleased) {
-          isReleased = false;
-          handleCtrlPanelTouched();
+        // Drain pending commands (non-blocking)
+        CtrlCommand cmd;
+        while (xQueueReceive(g_cmd_queue, &cmd, 0) == pdTRUE) {
+            switch (cmd.type) {
+                case CtrlCommandType::SET_KP:           kp = cmd.value; break;
+                case CtrlCommandType::SET_KI:           ki = cmd.value; break;
+                case CtrlCommandType::SET_KD:           kd = cmd.value; break;
+                case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
+            }
         }
-      }
-    vTaskDelayUntil(&xLastWakeTime, xPeriodMs*5);
-  }
+
+        // Compute dt from actual elapsed time
+        float dt;
+        if (prev_us == 0) {
+            dt = 0.010f;
+        } else {
+            dt = (float)(now_us - prev_us) / 1000000.0f;
+            dt = constrain(dt, 0.002f, 0.050f);
+        }
+        prev_us = now_us;
+
+        // IMU burst read
+        ImuData imu = readImuBurst();
+        if (!imu.valid) {
+            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            continue;
+        }
+
+        float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
+
+        float pitch_error = target - pitch_kalman;
+
+        // Fall detection
+        if (pitch_error < -40.0f || 40.0f < pitch_error) {
+            driveTire(0);
+            I_acc = 0.0f;
+            preP = 0.0f;
+            TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, 0, 0, 0, 0,
+                                 (uint32_t)(esp_timer_get_time() - now_us), true};
+            xQueueOverwrite(g_telemetry_queue, &tel);
+            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            continue;
+        }
+
+        // PID
+        float P_val = pitch_error;
+        I_acc += P_val * dt;
+        float i_limit = 200.0f / (fabsf(ki) + 1e-6f);
+        I_acc = constrain(I_acc, -i_limit, i_limit);
+        float D_val = (P_val - preP) / dt;
+        preP = P_val;
+
+        float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
+        int rpm_motor = constrain((int)rpm_f, -300, 300);
+        driveTire(rpm_motor);
+
+        // Telemetry (non-blocking overwrite)
+        uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
+        TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, (float)rpm_motor,
+                             P_val, I_acc, D_val, elapsed, false};
+        xQueueOverwrite(g_telemetry_queue, &tel);
+
+        vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+    }
 }
 
+// --- UI helpers ---
 
-void setup(){
-
-  DEBUG_SERIAL.begin(115200);
-
-  // M5 Settings (selective init: disable unused peripherals)
-  auto cfg = M5.config();
-  cfg.internal_rtc = false;
-  cfg.internal_mic = false;
-  cfg.internal_spk = false;
-  cfg.internal_imu = true;
-  M5.begin(cfg);
-  M5.Lcd.fillScreen(BLACK);
-  M5.Lcd.setTextSize(2);
-  M5.Lcd.setCursor(0, 0);
-
-  // Avatar disabled during architecture improvement (Phase 3-8)
-  // Will be re-enabled in Phase 9 after all improvements are stable.
-
-  // I2C mutex
-  g_i2c_mutex = xSemaphoreCreateMutex();
-  configASSERT(g_i2c_mutex != nullptr);
-
-  // DYNAMIXEL Settings
-  DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
-  dxl = Dynamixel2Arduino(DXL_SERIAL);
-  dxl.begin(1000000);  // DYNAMIXEL baudrate.
-  dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
-  dxl.ping(DXL_ID_L);
-  dxl.ping(DXL_ID_R);
-  dxl.torqueOff(DXL_ID_L);  // Turn off torque when configuring items in EEPROM area
-  dxl.torqueOff(DXL_ID_R);
-  dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
-  dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
-  dxl.torqueOn(DXL_ID_L);
-  dxl.torqueOn(DXL_ID_R);
-
-  // Kalman filter Setting (initial pitch via burst read)
-  ImuData imu_init = readImuBurst();
-  if (imu_init.valid) {
-    kalman.setAngle(imu_init.pitch_deg);
-  } else {
-    kalman.setAngle(86.0);
-  }
-
-  // WDT
-  esp_task_wdt_init(1, true);
-
-  // RTOS Task Settings
-  const uint32_t MEMORY_STACK = 8192;
-  const UBaseType_t PRIORITY_CTRL = 20;
-  const BaseType_t CORE_CTRL = 1;
-  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORITY_CTRL, NULL, CORE_CTRL);
-
-  const UBaseType_t PRIORITY_UI = 3;
-  const BaseType_t CORE_UI = 0;
-  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORITY_UI,   NULL, CORE_UI);
+void drawButton(const char* label, int x, int y, float value) {
+    M5.Display.drawRect(x, y, 50, 30, WHITE);
+    M5.Display.drawString("-", x + 20, y, 2);
+    M5.Display.drawRect(x + 200, y, 50, 30, WHITE);
+    M5.Display.drawString("+", x + 200 + 20, y, 2);
+    M5.Display.setCursor(x + 70, y + 5);
+    M5.Display.print(label);
+    M5.Display.print(": ");
+    M5.Display.println(value, 1);
 }
 
+// --- UI task ---
 
-void loop(){
+static float ui_kp = DEFAULT_KP;
+static float ui_ki = DEFAULT_KI;
+static float ui_kd = DEFAULT_KD;
+static float ui_target = DEFAULT_PITCH_TARGET;
+bool enShowCtrlPanel = false;
 
+void drawCtrlPanel() {
+    drawButton("Ref", 20, 30, ui_target);
+    drawButton("Kp", 20, 70, ui_kp);
+    drawButton("Ki", 20, 110, ui_ki);
+    drawButton("Kd", 20, 150, ui_kd);
+
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        int batteryPercentage = M5.Power.getBatteryLevel();
+        xSemaphoreGive(g_i2c_mutex);
+        M5.Display.setCursor(20, 190);
+        M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+    }
+}
+
+void handleCtrlPanelTouched() {
+    auto pos = M5.Touch.getDetail();
+    if (!pos.wasPressed()) return;
+
+    CtrlCommand cmd;
+    bool send = true;
+
+    if (pos.y >= 30 && pos.y < 60) {
+        if (pos.x >= 15 && pos.x < 120)      ui_target -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_target += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_PITCH_TARGET, ui_target}; drawButton("Ref", 20, 30, ui_target); }
+    }
+    else if (pos.y >= 70 && pos.y < 100) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kp -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kp += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KP, ui_kp}; drawButton("Kp", 20, 70, ui_kp); }
+    }
+    else if (pos.y >= 110 && pos.y < 140) {
+        if (pos.x >= 15 && pos.x < 120)      ui_ki -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_ki += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KI, ui_ki}; drawButton("Ki", 20, 110, ui_ki); }
+    }
+    else if (pos.y >= 150 && pos.y < 180) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kd -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kd += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KD, ui_kd}; drawButton("Kd", 20, 150, ui_kd); }
+    }
+    else {
+        send = false;
+    }
+
+    if (send) xQueueSend(g_cmd_queue, &cmd, 0);
+}
+
+void uiLoopTask(void *pvParameters) {
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    uint32_t last_telemetry_ms = 0;
+
+    while (true) {
+        if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            M5.update();
+            xSemaphoreGive(g_i2c_mutex);
+        }
+
+        // Toggle tuning panel
+        if (M5.BtnB.wasPressed()) {
+            enShowCtrlPanel = !enShowCtrlPanel;
+            M5.Lcd.clear();
+            if (enShowCtrlPanel) drawCtrlPanel();
+        }
+
+        if (enShowCtrlPanel) {
+            handleCtrlPanelTouched();
+        }
+
+        // Telemetry output via Serial (10Hz)
+        uint32_t now_ms = millis();
+        TelemetryData tel;
+        if (now_ms - last_telemetry_ms >= 100) {
+            if (xQueuePeek(g_telemetry_queue, &tel, 0) == pdTRUE) {
+                last_telemetry_ms = now_ms;
+                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n",
+                              tel.pitch_deg, tel.pitch_rate_dps, tel.rpm_cmd,
+                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us);
+            }
+        }
+
+        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(50));
+    }
+}
+
+// --- Setup ---
+
+void setup() {
+    Serial.begin(115200);
+
+    auto cfg = M5.config();
+    cfg.internal_rtc = false;
+    cfg.internal_mic = false;
+    cfg.internal_spk = false;
+    cfg.internal_imu = true;
+    M5.begin(cfg);
+    M5.Lcd.fillScreen(BLACK);
+    M5.Lcd.setTextSize(2);
+    M5.Lcd.setCursor(0, 0);
+
+    // I2C mutex
+    g_i2c_mutex = xSemaphoreCreateMutex();
+    configASSERT(g_i2c_mutex != nullptr);
+
+    // Inter-task queues
+    g_cmd_queue = xQueueCreate(8, sizeof(CtrlCommand));
+    g_telemetry_queue = xQueueCreate(1, sizeof(TelemetryData));
+    configASSERT(g_cmd_queue != nullptr);
+    configASSERT(g_telemetry_queue != nullptr);
+
+    // DYNAMIXEL Settings
+    DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
+    dxl = Dynamixel2Arduino(DXL_SERIAL);
+    dxl.begin(1000000);
+    dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
+
+    if (!dxl.ping(DXL_ID_L)) { M5.Lcd.println("DXL L ping FAIL"); }
+    if (!dxl.ping(DXL_ID_R)) { M5.Lcd.println("DXL R ping FAIL"); }
+    dxl.torqueOff(DXL_ID_L);
+    dxl.torqueOff(DXL_ID_R);
+    dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
+    dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
+    dxl.torqueOn(DXL_ID_L);
+    dxl.torqueOn(DXL_ID_R);
+
+    // Kalman filter init
+    ImuData imu_init = readImuBurst();
+    kalman.setAngle(imu_init.valid ? imu_init.pitch_deg : DEFAULT_PITCH_TARGET);
+
+    // WDT
+    esp_task_wdt_init(1, true);
+
+    // RTOS Tasks
+    const uint32_t MEMORY_STACK = 8192;
+    xTaskCreatePinnedToCore(controlLoopTask, "Control", MEMORY_STACK, NULL, 20, NULL, 1);
+    xTaskCreatePinnedToCore(uiLoopTask,      "UI",      MEMORY_STACK, NULL, 3,  NULL, 0);
+}
+
+void loop() {
 }


### PR DESCRIPTION
## Summary
- P4: UI→制御のコマンドキュー導入（Kp/Ki/Kd/target のスレッド安全な受け渡し）
- P7: DXL ping 戻り値チェック + 失敗時 LCD 表示
- P9: anti-windup を `I=0` リセットから `constrain` クランプに改善
- P10: `esp_timer_get_time()` による実測 dt（固定値 dt 廃止）
- P12: 制御→UI テレメトリキュー（`xQueueOverwrite`）+ Teleplot 形式 10Hz 出力
- P14: タッチ入力を `wasPressed()` エッジ検出に修正（repeat バグ解消）
- P15: `#ifdef ENABLE_DEBUG_PRINT` の DXL blocking read を完全削除

## Test plan
- [x] `pio run` ビルド成功
- [x] 実機書き込み・バランス動作正常
- [x] シリアルテレメトリ出力確認（`loop_us:2708` — 余裕あり）
- [x] タッチ UI 正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)