### PR TITLE
Kalman→Mahony AHRS 置換 + PID ゲイン再調整

### DIFF
--- a/include/imu_driver.h
+++ b/include/imu_driver.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <M5Unified.h>
+#include <freertos/semphr.h>
+
+class ImuDriver {
+public:
+    struct Data {
+        float pitch_deg;
+        float pitch_rate_dps;
+        bool valid;
+    };
+
+    void begin(SemaphoreHandle_t i2c_mutex);
+    Data update(float dt);
+
+    void calibrate(uint16_t n_samples = 500, float max_stddev_deg = 0.5f);
+
+    float pitchEstimate() const { return _pitch_est * RAD_TO_DEG; }
+
+private:
+    SemaphoreHandle_t _i2c_mutex = nullptr;
+
+    float _pitch_est = 0.0f;
+    float _gyro_bias = 0.0f;
+
+    static constexpr float KP_MAHONY = 2.0f;
+    static constexpr float KI_MAHONY = 0.005f;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,8 +13,9 @@ platform = espressif32@6.10.0
 board = m5stack-core2
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
+build_flags =
+	-I include
+lib_deps =
 	robotis-git/Dynamixel2Arduino@^0.8.1
 	m5stack/M5Unified@^0.2.7
-	tkjelectronics/Kalman Filter Library@^1.0.2
 	meganetaaan/M5Stack-Avatar@^0.9.2

--- a/src/imu_driver.cpp
+++ b/src/imu_driver.cpp
@@ -1,0 +1,70 @@
+#include "imu_driver.h"
+#include <cmath>
+
+void ImuDriver::begin(SemaphoreHandle_t i2c_mutex) {
+    _i2c_mutex = i2c_mutex;
+    _pitch_est = 0.0f;
+    _gyro_bias = 0.0f;
+}
+
+ImuDriver::Data ImuDriver::update(float dt) {
+    Data result = {0, 0, false};
+
+    if (xSemaphoreTake(_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) {
+        return result;
+    }
+    auto mask = M5.Imu.update();
+    xSemaphoreGive(_i2c_mutex);
+
+    if (!mask) return result;
+
+    auto imu = M5.Imu.getImuData();
+
+    float ay = imu.accel.y;
+    float az = imu.accel.z;
+    float gx = imu.gyro.x * DEG_TO_RAD;
+
+    float accel_pitch = atan2f(ay, az);
+    float error = accel_pitch - _pitch_est;
+
+    _gyro_bias += KI_MAHONY * error * dt;
+
+    float gyro_corrected = gx + KP_MAHONY * error + _gyro_bias;
+
+    _pitch_est += gyro_corrected * dt;
+
+    result.pitch_deg = _pitch_est * RAD_TO_DEG;
+    result.pitch_rate_dps = gyro_corrected * RAD_TO_DEG;
+    result.valid = true;
+    return result;
+}
+
+void ImuDriver::calibrate(uint16_t n_samples, float max_stddev_deg) {
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+
+    for (uint16_t i = 0; i < n_samples; i++) {
+        if (xSemaphoreTake(_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            M5.Imu.update();
+            xSemaphoreGive(_i2c_mutex);
+        }
+        auto imu = M5.Imu.getImuData();
+        float pitch = atan2f(imu.accel.y, imu.accel.z) * RAD_TO_DEG;
+        sum += pitch;
+        sum_sq += pitch * pitch;
+        vTaskDelay(pdMS_TO_TICKS(2));
+    }
+
+    float mean = sum / n_samples;
+    float variance = (sum_sq / n_samples) - (mean * mean);
+    float stddev = sqrtf(fabsf(variance));
+
+    if (stddev > max_stddev_deg) {
+        Serial.printf("IMU cal: stddev=%.2f > %.2f (vibration?)\n", stddev, max_stddev_deg);
+    }
+
+    _pitch_est = mean * DEG_TO_RAD;
+    _gyro_bias = 0.0f;
+
+    Serial.printf("IMU cal: pitch=%.2f deg, stddev=%.3f (%d samples)\n", mean, stddev, n_samples);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,11 @@
 
 #include <M5Unified.h>
 
-#include <Kalman.h>
 #include <Preferences.h>
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
 #include <esp_timer.h>
+#include "imu_driver.h"
 
 HardwareSerial& DXL_SERIAL = Serial1;
 
@@ -15,9 +15,9 @@ const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
 // Default controller params
-const float DEFAULT_KP = 50.0f;
-const float DEFAULT_KI = 1.0f;
-const float DEFAULT_KD = 1.0f;
+const float DEFAULT_KP = 15.0f;
+const float DEFAULT_KI = 0.05f;
+const float DEFAULT_KD = 0.0f;
 const float DEFAULT_PITCH_TARGET = 86.0f;
 const TickType_t xPeriodMs = 10;
 
@@ -27,7 +27,7 @@ const uint8_t DXL_ID_R = 1;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl;
-Kalman kalman;
+ImuDriver imuDriver;
 
 // I2C bus mutex
 SemaphoreHandle_t g_i2c_mutex = nullptr;
@@ -51,23 +51,6 @@ struct TelemetryData {
 QueueHandle_t g_cmd_queue = nullptr;
 QueueHandle_t g_telemetry_queue = nullptr;
 
-// --- IMU burst read ---
-
-struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
-
-ImuData readImuBurst() {
-    ImuData r = {0, 0, false};
-    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) return r;
-    auto mask = M5.Imu.update();
-    xSemaphoreGive(g_i2c_mutex);
-    if (!mask) return r;
-    auto d = M5.Imu.getImuData();
-    r.pitch_deg = atan2f(d.accel.y, d.accel.z) * RAD_TO_DEG;
-    r.pitch_rate_dps = d.gyro.x;
-    r.valid = true;
-    return r;
-}
-
 // --- Motor drive ---
 
 void driveTire(int rpm) {
@@ -87,6 +70,8 @@ void controlLoopTask(void *pvParameters) {
     float target = DEFAULT_PITCH_TARGET;
     float I_acc = 0.0f;
     float preP = 0.0f;
+    float D_filtered = 0.0f;
+    bool pid_active = false;
     int64_t prev_us = 0;
 
     while (true) {
@@ -114,23 +99,25 @@ void controlLoopTask(void *pvParameters) {
         }
         prev_us = now_us;
 
-        // IMU burst read
-        ImuData imu = readImuBurst();
+        // IMU read + Mahony fusion
+        auto imu = imuDriver.update(dt);
         if (!imu.valid) {
             vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
             continue;
         }
 
-        float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
+        float pitch_filtered = imu.pitch_deg;
 
-        float pitch_error = target - pitch_kalman;
+        float pitch_error = target - pitch_filtered;
 
         // Fall detection
         if (pitch_error < -40.0f || 40.0f < pitch_error) {
             driveTire(0);
             I_acc = 0.0f;
             preP = 0.0f;
-            TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, 0, 0, 0, 0,
+            D_filtered = 0.0f;
+            pid_active = false;
+            TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
                                  (uint32_t)(esp_timer_get_time() - now_us), true};
             xQueueOverwrite(g_telemetry_queue, &tel);
             vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
@@ -140,9 +127,19 @@ void controlLoopTask(void *pvParameters) {
         // PID
         float P_val = pitch_error;
         I_acc += P_val * dt;
-        float i_limit = 200.0f / (fabsf(ki) + 1e-6f);
+        float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
         I_acc = constrain(I_acc, -i_limit, i_limit);
-        float D_val = (P_val - preP) / dt;
+
+        float D_raw;
+        if (!pid_active) {
+            D_raw = 0.0f;
+            pid_active = true;
+        } else {
+            D_raw = (P_val - preP) / dt;
+        }
+        // Low-pass filter on D term (alpha=0.2: heavy smoothing)
+        D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
+        float D_val = D_filtered;
         preP = P_val;
 
         float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
@@ -151,7 +148,7 @@ void controlLoopTask(void *pvParameters) {
 
         // Telemetry (non-blocking overwrite)
         uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
-        TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, (float)rpm_motor,
+        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)rpm_motor,
                              P_val, I_acc, D_val, elapsed, false};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
@@ -309,9 +306,11 @@ void setup() {
     dxl.torqueOn(DXL_ID_L);
     dxl.torqueOn(DXL_ID_R);
 
-    // Kalman filter init
-    ImuData imu_init = readImuBurst();
-    kalman.setAngle(imu_init.valid ? imu_init.pitch_deg : DEFAULT_PITCH_TARGET);
+    // IMU driver init + calibration
+    imuDriver.begin(g_i2c_mutex);
+    M5.Lcd.println("Calibrating...");
+    imuDriver.calibrate(500, 0.5f);
+    M5.Lcd.println("Ready!");
 
     // WDT
     esp_task_wdt_init(1, true);


### PR DESCRIPTION
## Summary
- `ImuDriver` クラス新設: 1軸簡略化 Mahony AHRS（KP=2.0, KI=0.005）
- Kalman Filter Library を削除、起動時 500 サンプルキャリブレーション実装
- PID ゲインを Mahony 応答特性に合わせて再調整（Kp=15, Ki=0.05, Kd=0）
- D項にローパスフィルタ（α=0.2）追加、転倒復帰時リセット
- I項クランプ上限引き締め

## Why Mahony over Kalman?

TKJElectronics Kalman ライブラリの 1D Kalman フィルタには**ジャイロバイアスのオンライン補正機能がない**。
温度変化やセンサ経年劣化でジャイロバイアスがドリフトすると、ピッチ推定値が徐々にずれて
バランス制御の精度が低下する。

Mahony AHRS（1軸簡略化版）は PI 制御構造でジャイロバイアスを常時推定・補正する:
- P項（KP）: 加速度計ピッチとの誤差でジャイロレートを即時補正
- I項（KI）: 誤差の積分でバイアスドリフトを長期的に追従

これにより電源投入直後のウォームアップ中や長時間運転でもピッチ推定が安定する。
また実装が ~30 行と軽量で、外部ライブラリ依存を削除できるメリットもある。

## Tuning log
- Kp=50/Ki=1/Kd=1 + Mahony KP=10 → 激しい発振（D項爆発）
- Kp=30/Kd=0.3 → 改善するも発散傾向
- Kp=15/Kd=0 + Mahony KP=2 → **安定**。ロバストなバランス確認

## Test plan
- [x] `pio run` ビルド成功
- [x] 実機バランス動作安定
- [x] テレメトリ出力正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)