### PR TITLE
制御ループを 200Hz に引き上げ

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ const float DEFAULT_KP = 15.0f;
 const float DEFAULT_KI = 0.05f;
 const float DEFAULT_KD = 0.0f;
 const float DEFAULT_PITCH_TARGET = 86.0f;
-const TickType_t xPeriodMs = 10;
+const TickType_t CTRL_PERIOD_TICKS = pdMS_TO_TICKS(5);  // 200Hz
 
 // DYNAMIXEL Params.
 const uint8_t DXL_ID_L = 0;
@@ -102,7 +102,7 @@ void controlLoopTask(void *pvParameters) {
         // IMU read + Mahony fusion
         auto imu = imuDriver.update(dt);
         if (!imu.valid) {
-            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
@@ -120,7 +120,7 @@ void controlLoopTask(void *pvParameters) {
             TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
                                  (uint32_t)(esp_timer_get_time() - now_us), true};
             xQueueOverwrite(g_telemetry_queue, &tel);
-            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
@@ -152,7 +152,7 @@ void controlLoopTask(void *pvParameters) {
                              P_val, I_acc, D_val, elapsed, false};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
-        vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+        vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
     }
 }
 


### PR DESCRIPTION
## Summary
- `configTICK_RATE_HZ=1000` を実機で確認（Tier 1 成功、esp_timer 方式不要）
- 制御周期を 10ms (100Hz) → `pdMS_TO_TICKS(5)` = 5ms (200Hz) に変更
- raw tick 定数 `xPeriodMs` を廃止し `pdMS_TO_TICKS` マクロに統一
- `loop_us` ~2710us で 5000us 予算に余裕あり（54%）

## Test plan
- [x] `pio run` ビルド成功
- [x] 実機バランス動作正常（体感は 100Hz と大差なし）
- [x] `loop_us` が 5000us 以内

🤖 Generated with [Claude Code](https://claude.com/claude-code)