### PR TITLE
IMU キャリブレーション NVS 永続化

### DIFF
--- a/include/imu_driver.h
+++ b/include/imu_driver.h
@@ -14,6 +14,8 @@ public:
     Data update(float dt);
 
     void calibrate(uint16_t n_samples = 500, float max_stddev_deg = 0.5f);
+    bool loadNVS();
+    void saveNVS();
 
     float pitchEstimate() const { return _pitch_est * RAD_TO_DEG; }
 

--- a/src/imu_driver.cpp
+++ b/src/imu_driver.cpp
@@ -1,5 +1,6 @@
 #include "imu_driver.h"
 #include <cmath>
+#include <Preferences.h>
 
 void ImuDriver::begin(SemaphoreHandle_t i2c_mutex) {
     _i2c_mutex = i2c_mutex;
@@ -67,4 +68,31 @@ void ImuDriver::calibrate(uint16_t n_samples, float max_stddev_deg) {
     _gyro_bias = 0.0f;
 
     Serial.printf("IMU cal: pitch=%.2f deg, stddev=%.3f (%d samples)\n", mean, stddev, n_samples);
+}
+
+bool ImuDriver::loadNVS() {
+    Preferences prefs;
+    prefs.begin("imu_cal", true);
+    if (!prefs.isKey("pitch_init")) {
+        prefs.end();
+        return false;
+    }
+    float pitch_init = prefs.getFloat("pitch_init", 0.0f);
+    float bias = prefs.getFloat("gyro_bias", 0.0f);
+    prefs.end();
+
+    _pitch_est = pitch_init * DEG_TO_RAD;
+    _gyro_bias = bias;
+
+    Serial.printf("IMU NVS load: pitch=%.2f deg, bias=%.4f rad/s\n", pitch_init, bias);
+    return true;
+}
+
+void ImuDriver::saveNVS() {
+    Preferences prefs;
+    prefs.begin("imu_cal", false);
+    prefs.putFloat("pitch_init", _pitch_est * RAD_TO_DEG);
+    prefs.putFloat("gyro_bias", _gyro_bias);
+    prefs.end();
+    Serial.println("IMU cal saved to NVS");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,10 +306,13 @@ void setup() {
     dxl.torqueOn(DXL_ID_L);
     dxl.torqueOn(DXL_ID_R);
 
-    // IMU driver init + calibration
+    // IMU driver init
     imuDriver.begin(g_i2c_mutex);
-    M5.Lcd.println("Calibrating...");
-    imuDriver.calibrate(500, 0.5f);
+    if (!imuDriver.loadNVS()) {
+        M5.Lcd.println("Calibrating...");
+        imuDriver.calibrate(500, 0.5f);
+        imuDriver.saveNVS();
+    }
     M5.Lcd.println("Ready!");
 
     // WDT


### PR DESCRIPTION
## Summary
- `ImuDriver` に `loadNVS()` / `saveNVS()` を追加
- 起動時: NVS ロード成功 → キャリブスキップで即始動、失敗時のみライブキャリブ実施
- pitch 初期推定値とジャイロバイアスを `Preferences` で NVS に永続化
- `pio run --target erase` で NVS クリア → 再キャリブ可能

## Test plan
- [x] `pio run` ビルド成功
- [x] 初回起動: "Calibrating..." 表示 → バランス動作
- [x] 再起動: キャリブスキップ → 即始動

🤖 Generated with [Claude Code](https://claude.com/claude-code)