### PR TITLE
Phase S-A: PID ベース速度制御

### DIFF
--- a/docs/control-loop.drawio.svg
+++ b/docs/control-loop.drawio.svg
@@ -1,0 +1,158 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="600px" height="1020px" viewBox="50.0 0.0 600.0 1020.0" style="background: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;
+    &lt;diagram name=&quot;Control Loop&quot; id=&quot;ctrl-loop&quot;&gt;
+        &lt;mxGraphModel dx=&quot;800&quot; dy=&quot;600&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;827&quot; pageHeight=&quot;1169&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;
+            &lt;root&gt;
+                &lt;mxCell id=&quot;0&quot;/&gt;
+                &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;
+                &lt;mxCell id=&quot;2&quot; value=&quot;WDT Reset + Command Queue&amp;#xa;(PID + Speed commands)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;95&quot; y=&quot;10&quot; width=&quot;260&quot; height=&quot;45&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;3&quot; value=&quot;dt calc + IMU update (Mahony)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;95&quot; y=&quot;80&quot; width=&quot;260&quot; height=&quot;45&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;4&quot; value=&quot;IMU valid?&quot; style=&quot;rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;170&quot; y=&quot;155&quot; width=&quot;110&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;5&quot; value=&quot;Fall detection&amp;#xa;|target - pitch| &gt; 40deg?&quot; style=&quot;rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;140&quot; y=&quot;250&quot; width=&quot;170&quot; height=&quot;70&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;7&quot; value=&quot;Fall: Motor OFF&amp;#xa;PID + Speed Reset&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#fdedec;strokeColor=#e74c3c;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;420&quot; y=&quot;260&quot; width=&quot;160&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;20&quot; value=&quot;Speed outer loop (25 Hz)&amp;#xa;Sync Read → Speed PI → θ_offset&amp;#xa;(back-calc anti-windup)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#fce5cd;strokeColor=#d79b00;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;75&quot; y=&quot;360&quot; width=&quot;300&quot; height=&quot;65&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;21&quot; value=&quot;effective_target = target - θ_offset&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;80&quot; y=&quot;460&quot; width=&quot;290&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;8&quot; value=&quot;Inner PID/PD&amp;#xa;Speed: D=-rate (on-measurement)&amp;#xa;Normal: D=LPF(dP/dt, α=0.2)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;75&quot; y=&quot;535&quot; width=&quot;300&quot; height=&quot;65&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;9&quot; value=&quot;Speed: rpm = Kp*P + Kd*D&amp;#xa;Normal: rpm = Kp*P + Ki*I + Kd*D&amp;#xa;constrain(-300, +300)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;75&quot; y=&quot;635&quot; width=&quot;300&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;10&quot; value=&quot;driveMotors(rpm, rpm)&amp;#xa;Sync Write Goal Velocity&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;105&quot; y=&quot;730&quot; width=&quot;240&quot; height=&quot;45&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;11&quot; value=&quot;Telemetry send (overwrite)&amp;#xa;+speed fields&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;105&quot; y=&quot;810&quot; width=&quot;240&quot; height=&quot;45&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+                &lt;mxCell id=&quot;12&quot; value=&quot;vTaskDelayUntil (5ms)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=12;fontStyle=1;&quot; parent=&quot;1&quot; vertex=&quot;1&quot;&gt;
+                    &lt;mxGeometry x=&quot;105&quot; y=&quot;890&quot; width=&quot;240&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;
+                &lt;/mxCell&gt;
+            &lt;/root&gt;
+        &lt;/mxGraphModel&gt;
+    &lt;/diagram&gt;
+&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#555"/>
+        </marker>
+    </defs>
+    <g>
+<!-- Box 1: WDT + Command Queue -->
+<rect x="95" y="10" width="260" height="45" rx="10" ry="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+<text x="225" y="30" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">WDT Reset + Command Queue</text>
+<text x="225" y="46" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" fill="#333">(PID + Speed commands)</text>
+
+<!-- Arrow 1→2 -->
+<line x1="225" y1="55" x2="225" y2="80" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box 2: dt + IMU -->
+<rect x="95" y="80" width="260" height="45" rx="10" ry="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+<text x="225" y="108" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">dt calc + IMU update (Mahony)</text>
+
+<!-- Arrow 2→diamond -->
+<line x1="225" y1="125" x2="225" y2="155" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Diamond: IMU valid? -->
+<polygon points="225,155 280,185 225,215 170,185" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+<text x="225" y="190" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">IMU valid?</text>
+
+<!-- Diamond Yes arrow down -->
+<line x1="225" y1="215" x2="225" y2="250" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+<text x="233" y="236" font-family="Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#82b366">Yes</text>
+
+<!-- Diamond No arrow right → 5ms wait -->
+<path d="M 280 185 L 620 185 L 620 890 L 345 890" fill="none" stroke="#e74c3c" stroke-width="2" marker-end="url(#arrowhead)"/>
+<text x="290" y="178" font-family="Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#e74c3c">No</text>
+
+<!-- Diamond 2: Fall detection -->
+<polygon points="225,250 310,285 225,320 140,285" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+<text x="225" y="282" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" font-weight="bold" fill="#333">|target-pitch|</text>
+<text x="225" y="296" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" font-weight="bold" fill="#333">&gt; 40 deg?</text>
+
+<!-- Diamond2 No arrow down -->
+<line x1="225" y1="320" x2="225" y2="360" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+<text x="233" y="343" font-family="Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#82b366">No</text>
+
+<!-- Diamond2 Yes arrow right → Fall box -->
+<line x1="310" y1="285" x2="420" y2="285" stroke="#e74c3c" stroke-width="2" marker-end="url(#arrowhead)"/>
+<text x="340" y="278" font-family="Helvetica, sans-serif" font-size="11" font-weight="bold" fill="#e74c3c">Yes</text>
+
+<!-- Fall box -->
+<rect x="420" y="260" width="160" height="50" rx="10" ry="10" fill="#fdedec" stroke="#e74c3c" stroke-width="2"/>
+<text x="500" y="280" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#e74c3c">Fall: Motor OFF</text>
+<text x="500" y="298" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#e74c3c">PID + Speed Reset</text>
+
+<!-- Fall → Telemetry -->
+<path d="M 500 310 L 500 810 L 345 810" fill="none" stroke="#e74c3c" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: Speed outer loop -->
+<rect x="75" y="360" width="300" height="65" rx="10" ry="10" fill="#fce5cd" stroke="#d79b00" stroke-width="2"/>
+<text x="225" y="380" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">Speed Outer Loop (25 Hz)</text>
+<text x="225" y="396" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#333">Sync Read → Speed PI → θ_offset</text>
+<text x="225" y="412" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" fill="#666">(back-calc anti-windup, budget guard)</text>
+
+<!-- Arrow speed→effective_target -->
+<line x1="225" y1="425" x2="225" y2="460" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: effective_target -->
+<rect x="80" y="460" width="290" height="40" rx="10" ry="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+<text x="225" y="485" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">effective_target = target - θ_offset</text>
+
+<!-- Arrow effective_target→PID -->
+<line x1="225" y1="500" x2="225" y2="535" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: Inner PID/PD -->
+<rect x="75" y="535" width="300" height="65" rx="10" ry="10" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+<text x="225" y="555" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">Inner PID/PD</text>
+<text x="225" y="572" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#333">Speed: D = -rate (on-measurement)</text>
+<text x="225" y="589" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#333">Normal: D = LPF(dP/dt, α=0.2)</text>
+
+<!-- Arrow PID→RPM -->
+<line x1="225" y1="600" x2="225" y2="635" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: RPM calc -->
+<rect x="75" y="635" width="300" height="60" rx="10" ry="10" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+<text x="225" y="655" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">RPM Output</text>
+<text x="225" y="672" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#333">Speed: Kp·P + Kd·D</text>
+<text x="225" y="687" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="11" fill="#333">Normal: Kp·P + Ki·I + Kd·D  ±300</text>
+
+<!-- Arrow RPM→driveMotors -->
+<line x1="225" y1="695" x2="225" y2="730" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: driveMotors -->
+<rect x="105" y="730" width="240" height="45" rx="10" ry="10" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+<text x="225" y="750" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">driveMotors(rpm, rpm)</text>
+<text x="225" y="766" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" fill="#333">Sync Write Goal Velocity</text>
+
+<!-- Arrow driveMotors→Telemetry -->
+<line x1="225" y1="775" x2="225" y2="810" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: Telemetry -->
+<rect x="105" y="810" width="240" height="45" rx="10" ry="10" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+<text x="225" y="830" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">Telemetry send (overwrite)</text>
+<text x="225" y="846" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="10" fill="#333">PID + speed fields</text>
+
+<!-- Arrow Telemetry→Wait -->
+<line x1="225" y1="855" x2="225" y2="890" stroke="#555" stroke-width="2" marker-end="url(#arrowhead)"/>
+
+<!-- Box: Wait -->
+<rect x="105" y="890" width="240" height="40" rx="10" ry="10" fill="#f5f5f5" stroke="#666666" stroke-width="2"/>
+<text x="225" y="915" text-anchor="middle" font-family="Helvetica, sans-serif" font-size="12" font-weight="bold" fill="#333">vTaskDelayUntil (5ms)</text>
+
+<!-- Loop back arrow -->
+<path d="M 105 910 L 60 910 L 60 32 L 95 32" fill="none" stroke="#666" stroke-width="2" marker-end="url(#arrowhead)"/>
+    </g>
+</svg>

--- a/docs/firmware-guide.md
+++ b/docs/firmware-guide.md
@@ -1,0 +1,587 @@
+# BSL-Balancer ファームウェア設計ガイド
+
+> **対象読者**: 本プロジェクトに新規アサインされたエンジニア
+> **対象コード**: `firmware/bsl-balancer/` 配下の全ソースコード
+> **最終更新**: 2026-06-13
+
+---
+
+## 目次
+
+1. [プロジェクト概要](#1-プロジェクト概要)
+2. [ハードウェア構成](#2-ハードウェア構成)
+3. [ソフトウェアアーキテクチャ](#3-ソフトウェアアーキテクチャ)
+4. [ファイル構成と役割](#4-ファイル構成と役割)
+5. [初期化シーケンス — main.cpp](#5-初期化シーケンス--maincpp)
+6. [制御ループ — control_task.cpp](#6-制御ループ--control_taskcpp)
+7. [IMU センサフュージョン — imu_driver.cpp](#7-imu-センサフュージョン--imu_drivercpp)
+8. [UI タスク — ui_task.cpp](#8-ui-タスク--ui_taskcpp)
+9. [アバター描画 — TairinEye / TairinMouth](#9-アバター描画--tairineye--tairinmouth)
+10. [タスク間通信の詳細](#10-タスク間通信の詳細)
+11. [定数・設定値一覧](#11-定数設定値一覧)
+12. [ビルドと書き込み](#12-ビルドと書き込み)
+13. [レガシーコード (Arduino IDE 版) との差分](#13-レガシーコード-arduino-ide-版-との差分)
+
+---
+
+## 1. プロジェクト概要
+
+BSL-Balancer（愛称: ﾀｲﾘﾝﾁｬﾝ）は、**対向二輪型倒立振子ロボット**のファームウェアである。M5Stack Core2 を MCU 兼ディスプレイとして使用し、DYNAMIXEL XL330 サーボモータ2基で車輪を駆動する。PID 制御によるリアルタイム姿勢安定化を行い、タッチパネルによるパラメータ調整機能を備える。
+
+主な特徴:
+
+- **200Hz 制御ループ**: FreeRTOS デュアルコア構成で制御と UI を分離
+- **Mahony フィルタ**: 加速度計＋ジャイロスコープの相補フィルタによる姿勢推定
+- **転倒検知**: ピッチ偏差 ±40° 超過でモータ即時停止
+- **アバター描画部品** (未統合): m5stack-avatar 用カスタム描画クラス（TairinEye/TairinMouth）がソースに含まれるが、現在の main.cpp/ui_task.cpp からは呼び出されていない
+
+---
+
+## 2. ハードウェア構成
+
+![Hardware Architecture](./hw-architecture.drawio.svg)
+
+### 2.1 構成部品
+
+| コンポーネント | 型番 | 数量 | 役割 |
+|---|---|---|---|
+| MCU | M5Stack Core2 (ESP32) | 1 | 制御・表示・IMU 内蔵 |
+| サーボモータ | DYNAMIXEL XL330-M077-T | 2 | 車輪駆動（速度モード） |
+| IF ボード | B-SKY Lab オリジナル | 1 | DYNAMIXEL TTL 通信変換 |
+| ケーブル | M5STACK-CABLE-10 | 1 | PORT A 接続 |
+| 電池ボックス | SBH-431-1AS150 | 1 | モータ電源 (3×AAA = 4.5V) |
+| タイヤ | TAMIYA ナロータイヤ | 1 セット | 走行用 |
+| 筐体 | 3D プリンタ製パーツ | 1 セット | `case/` ディレクトリ内 STL |
+
+### 2.2 通信インタフェース
+
+| バス | ピン | ボーレート | 用途 |
+|---|---|---|---|
+| UART1 (Serial1) | GPIO32 (TX) / GPIO33 (RX) | 1,000,000 bps | DYNAMIXEL 制御 |
+| I2C (内部) | — | — | MPU-6886 IMU / バッテリ監視 |
+| USB (Serial0) | — | 115,200 bps | デバッグ用テレメトリ出力 |
+
+### 2.3 M5Stack Core2 内蔵ペリフェラル
+
+- **IMU**: MPU-6886 (3 軸加速度 + 3 軸ジャイロ)
+- **LCD**: ILI9342C 320×240px カラーディスプレイ
+- **タッチ**: FT6336U 静電容量式タッチパネル (I2C addr 0x38)
+- **電源管理**: AXP192 PMIC (バッテリ残量取得可能)
+
+---
+
+## 3. ソフトウェアアーキテクチャ
+
+![Software Architecture](./sw-architecture.drawio.svg)
+
+### 3.1 デュアルコア・タスク構成
+
+ESP32 のデュアルコアを活用し、FreeRTOS タスクを以下のように分離している:
+
+| タスク | Core | 優先度 | 周期 | スタック | 役割 |
+|---|---|---|---|---|---|
+| `controlLoopTask` | Core 1 (APP_CPU) | 20 | 5ms (200Hz) | 8192 bytes | IMU 読取・PID 制御・モータ駆動 |
+| `uiLoopTask` | Core 0 (PRO_CPU) | 3 | 50ms (20Hz) | 8192 bytes | タッチ入力・画面描画・テレメトリ |
+
+制御タスクが最高優先度で、UI タスクに割り込まれることはない。
+
+### 3.2 タスク間通信機構
+
+タスク間の通信には FreeRTOS のプリミティブを3つ使用する:
+
+1. **`g_cmd_queue`** (深さ 8): UI → Control 方向のパラメータ変更指令
+2. **`g_telemetry_queue`** (深さ 1, 上書き): Control → UI 方向の状態データ
+3. **`g_i2c_mutex`**: I2C バスの排他制御（IMU 読取とバッテリ監視の衝突防止）
+
+### 3.3 ウォッチドッグ
+
+制御タスクは `esp_task_wdt` により 1 秒のウォッチドッグタイマーで監視される。制御ループが 1 秒以内に `esp_task_wdt_reset()` を呼ばないと MCU がリセットされる。
+
+---
+
+## 4. ファイル構成と役割
+
+```
+firmware/bsl-balancer/
+├── platformio.ini          # ビルド設定・ライブラリ依存
+├── include/
+│   ├── config.h            # ハードウェア定数・PID デフォルト値
+│   ├── shared_state.h      # タスク間通信の構造体・キュー宣言
+│   └── imu_driver.h        # IMU ドライバ (Mahony フィルタ) ヘッダ
+├── src/
+│   ├── main.cpp            # エントリポイント: 初期化 + タスク生成
+│   ├── control_task.cpp    # 制御ループ: PID + 転倒検知 + モータ駆動
+│   ├── ui_task.cpp         # UI ループ: タッチ操作 + テレメトリ
+│   ├── imu_driver.cpp      # Mahony 相補フィルタ実装
+│   ├── TairinEye.h/.cpp    # カスタム目描画 (m5avatar 拡張)
+│   └── TairinMouth.h/.cpp  # カスタム口描画 (m5avatar 拡張)
+├── case/                   # 3D プリンタ用 STL ファイル
+├── docs/                   # ドキュメント・写真
+└── for_arduino_ide/        # [非推奨] Arduino IDE 版レガシーコード
+```
+
+### ライブラリ依存 (platformio.ini)
+
+| ライブラリ | バージョン | 用途 |
+|---|---|---|
+| `Dynamixel2Arduino` | ^0.8.1 | DYNAMIXEL プロトコル 2.0 通信 |
+| `M5Unified` | ^0.2.7 | M5Stack 統一 HAL (IMU, LCD, 電源) |
+| `M5Stack-Avatar` | ^0.9.2 | 顔アニメーション描画 |
+
+---
+
+## 5. 初期化シーケンス — main.cpp
+
+`setup()` 関数が以下の順序で初期化を行う:
+
+### 5.1 M5Stack Core2 初期化
+
+```cpp
+auto cfg = M5.config();
+cfg.internal_imu = true;   // IMU 有効化
+M5.begin(cfg);
+```
+
+RTC, マイク, スピーカーは無効化し、IMU のみ有効にする。
+
+### 5.2 FreeRTOS プリミティブ生成
+
+```cpp
+g_i2c_mutex      = xSemaphoreCreateMutex();       // I2C 排他制御
+g_cmd_queue      = xQueueCreate(8, sizeof(CtrlCommand));     // コマンドキュー
+g_telemetry_queue = xQueueCreate(1, sizeof(TelemetryData));  // テレメトリキュー
+```
+
+すべて `configASSERT` で生成成功を検証する。失敗時は MCU が停止する。
+
+### 5.3 DYNAMIXEL 初期化
+
+```cpp
+HardwareSerial& dxl_serial = Serial1;
+dxl_serial.begin(DXL_BAUDRATE, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
+dxl = Dynamixel2Arduino(dxl_serial);
+dxl.begin(DXL_BAUDRATE);
+dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
+if (!dxl.ping(DXL_ID_L)) { M5.Lcd.println("DXL L ping FAIL"); }
+if (!dxl.ping(DXL_ID_R)) { M5.Lcd.println("DXL R ping FAIL"); }
+dxl.torqueOff(DXL_ID_L);
+dxl.torqueOff(DXL_ID_R);
+dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
+dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
+dxl.torqueOn(DXL_ID_L);
+dxl.torqueOn(DXL_ID_R);
+```
+
+1. UART1 を 1Mbps で開く（PORT A: GPIO32/33）
+2. `Dynamixel2Arduino` インスタンスにシリアルポートを割り当て、通信開始
+3. 各モータに ping を送信し接続確認（失敗時は LCD にエラー表示）
+4. トルク OFF → 速度モード設定 → トルク ON の順で設定
+
+### 5.4 IMU キャリブレーション
+
+```cpp
+imuDriver.calibrate(500, 0.5f);
+```
+
+500 サンプルの加速度ピッチ角を平均して初期姿勢推定値とする。標準偏差が 0.5° を超える場合は振動警告をシリアル出力する。
+
+### 5.5 タスク生成
+
+```cpp
+esp_task_wdt_init(1, true);  // WDT 1秒, パニック有効
+xTaskCreatePinnedToCore(controlLoopTask, "Control", 8192, NULL, 20, NULL, 1);
+xTaskCreatePinnedToCore(uiLoopTask,      "UI",      8192, NULL, 3,  NULL, 0);
+```
+
+Arduino の `loop()` は空。すべての処理は FreeRTOS タスクで実行される。
+
+---
+
+## 6. 制御ループ — control_task.cpp
+
+200Hz (5ms 周期) で実行される倒立制御の中核タスク。
+
+![Control Loop](./control-loop.drawio.svg)
+
+### 6.1 ループ構造
+
+各反復で以下を順に実行する:
+
+1. **WDT リセット** — `esp_task_wdt_reset()`
+2. **コマンドキュー処理** — UI からの Kp/Ki/Kd/Target 変更をノンブロッキングで全消費
+3. **Δt 計算** — `esp_timer_get_time()` による実測、2ms〜50ms にクランプ
+4. **IMU 更新** — Mahony フィルタで姿勢推定（後述）
+5. **転倒判定** — ピッチ偏差 ±40° で転倒と判定
+6. **PID 計算** — 正常時のみ実行
+7. **モータ駆動** — RPM 値を DYNAMIXEL に送信
+8. **テレメトリ送信** — 上書きキューで最新値を UI タスクに提供
+9. **待機** — `vTaskDelayUntil()` で周期精度を保証
+
+### 6.2 PID 制御の詳細
+
+#### P 項 (比例)
+
+```
+P = target - pitch_filtered
+```
+
+偏差そのもの。`target` のデフォルトは 86.0°（機体の垂直姿勢に対応）。
+
+#### I 項 (積分) — アンチワインドアップ付き
+
+```
+I_acc += P * dt
+i_limit = 50.0 / (|ki| + 1e-6)
+I_acc = clamp(I_acc, -i_limit, i_limit)
+```
+
+積分値を `ki * I_acc` の絶対値が 50 RPM を超えない範囲に制限する。これにより転倒後の復帰時に積分巻き上げ (windup) が発生しない。
+
+#### D 項 (微分) — ローパスフィルタ付き
+
+```
+D_raw = (P - preP) / dt
+D_filtered = 0.2 * D_raw + 0.8 * D_filtered
+```
+
+1 次 IIR ローパスフィルタ (α=0.2) で高周波ノイズを抑制する。初回反復 (`pid_active == false`) では D 項をゼロにする。
+
+#### 出力計算
+
+```
+rpm = Kp * P + Ki * I_acc + Kd * D_filtered
+rpm_motor = constrain(rpm, -300, 300)
+```
+
+計算結果を ±300 RPM に制限してモータへ送信する。
+
+### 6.3 転倒検知と復帰
+
+ピッチ偏差が ±40° を超えると:
+
+1. モータを即時停止 (`driveMotors(0, 0)`)
+2. PID 内部状態をリセット (`I_acc = 0, preP = 0, D_filtered = 0`)
+3. 速度制御状態をリセット (`speed_enabled = false`, `v_d = 0`, `yaw_rate_cmd = 0`, 積分項・計測値クリア)
+4. `pid_active = false` にして、復帰時の D 項スパイクを防止
+5. テレメトリに `fallen = true` を設定して送信
+
+偏差が ±40° 以内に戻ると自動的に制御を再開する。
+
+### 6.4 モータ駆動関数
+
+```cpp
+static void driveMotors(int rpm_L, int rpm_R) {
+    // Sync Write で左右同時に Goal Velocity を書き込み（非ブロッキング）
+    int32_t raw_L = (int32_t)(-rpm_L / DXL_VEL_UNIT);
+    int32_t raw_R = (int32_t)( rpm_R / DXL_VEL_UNIT);
+    memcpy(goal_vel_buf_L, &raw_L, 4);
+    memcpy(goal_vel_buf_R, &raw_R, 4);
+    vel_sync_write.is_info_changed = true;
+    dxl.syncWrite(&vel_sync_write);
+}
+```
+
+`Sync Write` パケットにより左右モータへ同時に Goal Velocity を送信する。左右のモータは逆方向に取り付けられているため、左モータに `-rpm` を指令する。速度制御有効時はヨーレート指令に基づく差動ミキシングが適用される。
+
+---
+
+## 7. IMU センサフュージョン — imu_driver.cpp
+
+### 7.1 Mahony 相補フィルタ
+
+加速度計とジャイロスコープを融合して安定したピッチ角推定を行う。1 次元（ピッチ軸のみ）の簡略版を実装している。
+
+#### アルゴリズム
+
+```
+accel_pitch = atan2(ay, az)                    // 加速度からのピッチ角
+error       = accel_pitch - pitch_est          // 推定値との誤差
+
+gyro_bias  += KI_MAHONY * error * dt           // ジャイロバイアス補正（積分）
+gyro_corr   = gx + KP_MAHONY * error + gyro_bias  // 補正済みジャイロ角速度
+
+pitch_est  += gyro_corr * dt                   // 姿勢推定値の更新
+```
+
+#### パラメータ
+
+| 定数 | 値 | 役割 |
+|---|---|---|
+| `KP_MAHONY` | 2.0 | 比例ゲイン — 加速度計への追従速度 |
+| `KI_MAHONY` | 0.005 | 積分ゲイン — ジャイロドリフト補正速度 |
+
+KP が大きいほど加速度計の影響が強く振動に弱い。KI はジャイロのゆっくりしたドリフトを補正する。
+
+### 7.2 I2C 排他制御
+
+IMU の読み取りは I2C 経由で行うため、`g_i2c_mutex` を 2ms タイムアウトで取得する。取得できない場合は `valid = false` を返し、制御ループはその反復をスキップする。
+
+```cpp
+if (xSemaphoreTake(_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) {
+    return {0, 0, false};  // mutex 取得失敗 → スキップ
+}
+auto mask = M5.Imu.update();
+xSemaphoreGive(_i2c_mutex);
+```
+
+### 7.3 キャリブレーション
+
+起動時に `calibrate()` が呼ばれ、以下を行う:
+
+1. 500 サンプルの加速度ピッチ角を 2ms 間隔で収集
+2. 平均値を初期 `pitch_est` として設定
+3. ジャイロバイアスをゼロにリセット
+4. 標準偏差が閾値 (0.5°) を超えた場合はシリアルに警告出力
+
+---
+
+## 8. UI タスク — ui_task.cpp
+
+20Hz (50ms 周期) で実行される画面表示・入力処理タスク。
+
+### 8.1 タッチパネルによるパラメータ調整
+
+ボタン B（中央）を押すとコントロールパネルが表示される。各パラメータに [−] / [+] ボタンが配置され、タッチで 0.2 ずつ増減できる:
+
+| パラメータ | 画面ラベル | デフォルト値 | 説明 |
+|---|---|---|---|
+| `pitch_target` | Ref | 86.0° | 目標ピッチ角（垂直姿勢） |
+| `kp` | Kp | 15.0 | 比例ゲイン |
+| `ki` | Ki | 0.05 | 積分ゲイン |
+| `kd` | Kd | 0.0 | 微分ゲイン（デフォルト無効） |
+
+変更は `CtrlCommand` 構造体としてキューに送信され、制御タスクが次の反復で反映する。
+
+### 8.2 テレメトリ出力
+
+100ms 間隔でシリアル (USB) に以下の形式でテレメトリを出力する:
+
+```
+>pitch:86.12
+>rate:-0.34
+>rpm:5.0
+>P:0.12
+>I:0.003
+>D:0.02
+>loop_us:312
+```
+
+`>` プレフィックス付きのフォーマットは、シリアルプロッタ対応の形式。
+
+### 8.3 バッテリ残量表示
+
+コントロールパネル表示中、`M5.Power.getBatteryLevel()` でバッテリ残量を取得して画面下部に表示する。この呼び出しは I2C 経由のため `g_i2c_mutex` で保護されている。
+
+### 8.4 M5.update() の排他制御
+
+`M5.update()` は内部で I2C を使用するため（ボタン状態読み取り等）、mutex 取得下で呼び出す:
+
+```cpp
+if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    M5.update();
+    xSemaphoreGive(g_i2c_mutex);
+}
+```
+
+---
+
+## 9. アバター描画 — TairinEye / TairinMouth
+
+m5stack-avatar ライブラリの `Drawable` インタフェースを継承したカスタムコンポーネント。ロボットの顔表示を担当する。
+
+### 9.1 TairinEye (目)
+
+- **開眼時**: `fillCircle()` で円形の目を描画
+- **閉眼時**: `fillRect()` で水平線（まばたき）を描画
+- **視線追従**: `Gaze` オブジェクトの水平/垂直成分に応じて ±3px のオフセット
+
+#### 花飾り描画
+
+画面右上に「大輪の花」（ﾀｲﾘﾝ = 大輪）モチーフの装飾を描画する:
+
+```
+r = |a·sin(nθ) + b·sin(3nθ) + c·sin(5nθ)|
+```
+
+パラメータ: n=5（花弁は 2n=10 枚）、a=30, b=6, c=1。バラ曲線（rose curve）の変種を極座標からデカルト座標に変換して描画する。
+
+`en_draw_flower` フラグにより 1 フレーム置きに描画し、アニメーション時の線の重複を防ぐ。
+
+### 9.2 TairinMouth (口)
+
+`openRatio` に応じて矩形の口を描画する:
+
+- `openRatio = 0`: 最小幅 (`maxWidth`) × 最小高 (`minHeight`) → 閉じた口
+- `openRatio = 1`: 最小幅 (`minWidth`) × 最大高 (`maxHeight`) → 開いた口
+- `breath` パラメータにより Y 方向に微小な揺れアニメーションを付与
+
+---
+
+## 10. タスク間通信の詳細
+
+### 10.1 CtrlCommand 構造体
+
+```cpp
+enum class CtrlCommandType : uint8_t {
+    SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
+    SET_SPEED_ENABLED,   // value > 0.5 で速度制御 ON、≤ 0.5 で OFF
+    SET_KP_SPEED,        // 速度 PI の Kp
+    SET_KI_SPEED,        // 速度 PI の Ki
+    SET_VELOCITY_CMD,    // 目標並進速度 [m/s]（±V_CMD_MAX でクランプ）
+    SET_YAW_RATE_CMD,    // 目標ヨーレート [rad/s]
+};
+struct CtrlCommand {
+    CtrlCommandType type;
+    float value;
+};
+```
+
+UI タスクがパラメータ変更時に `xQueueSend()` でキューに投入する。制御タスクはループ先頭で `xQueueReceive()` をノンブロッキング (`timeout=0`) で全メッセージを消費する。キュー深さ 8 のため、1 制御周期 (5ms) で最大 8 件のパラメータ変更を処理できる。
+
+速度制御コマンド (`SET_VELOCITY_CMD` / `SET_YAW_RATE_CMD`) は `CMD_FRESHNESS_MS` 以内に再送されなければデッドマンタイムアウトで速度制御が自動停止する。`SET_SPEED_ENABLED` 受信時にもタイマーがリフレッシュされる。
+
+### 10.2 TelemetryData 構造体
+
+```cpp
+struct TelemetryData {
+    float pitch_deg;        // 推定ピッチ角 [deg]
+    float pitch_rate_dps;   // ピッチ角速度 [deg/s]
+    float rpm_cmd;          // モータ RPM 指令値
+    float P_term, I_term, D_term;  // PID 各項
+    uint32_t loop_us;       // 制御ループ実行時間 [us]
+    bool fallen;            // 転倒フラグ
+    float v_measured;       // 計測車輪速度 [m/s]
+    float theta_offset;     // 速度 PI 出力のピッチオフセット [deg]
+    float v_error;          // 速度誤差 [m/s]
+    float v_integral;       // 速度積分項
+    uint32_t sync_read_us;  // Sync Read 所要時間 [us]
+    bool speed_enabled;     // 速度制御有効フラグ
+};
+```
+
+制御タスクが `xQueueOverwrite()` で最新値を常に上書きする。UI タスクは `xQueuePeek()` で読み取る（キューから消費しない）。これにより:
+
+- 制御タスクはキュー満杯でブロックされない
+- UI タスクは常に最新のテレメトリを取得できる
+- 読み取りタイミングが制御周期と非同期でも問題ない
+
+### 10.3 I2C Mutex
+
+I2C バスは以下の 2 つのコンテキストで使用される:
+
+| 使用元 | 用途 | タイムアウト |
+|---|---|---|
+| `imuDriver.update()` (Control) | IMU データ読み取り | 2ms |
+| `M5.update()` / `getBatteryLevel()` (UI) | ボタン状態 / バッテリ残量 | 10ms |
+
+制御タスクのタイムアウトが短い (2ms) のは、制御周期 (5ms) に対して遅延を最小化するため。取得失敗時は IMU データを `invalid` として返し、その反復の制御計算をスキップする。
+
+---
+
+## 11. 定数・設定値一覧
+
+### config.h で定義される定数
+
+| 定数名 | 値 | 説明 |
+|---|---|---|
+| `PIN_RX_SERVO` | GPIO33 | DYNAMIXEL UART RX ピン |
+| `PIN_TX_SERVO` | GPIO32 | DYNAMIXEL UART TX ピン |
+| `DEFAULT_KP` | 15.0 | PID 比例ゲインのデフォルト値 |
+| `DEFAULT_KI` | 0.05 | PID 積分ゲインのデフォルト値 |
+| `DEFAULT_KD` | 0.0 | PID 微分ゲインのデフォルト値（無効） |
+| `DEFAULT_PITCH_TARGET` | 86.0° | 目標ピッチ角のデフォルト値 |
+| `CTRL_PERIOD_TICKS` | 5ms (200Hz) | 制御ループ周期 |
+| `DXL_ID_L` / `DXL_ID_R` | 0 / 1 | 左右モータの DYNAMIXEL ID |
+| `DXL_PROTOCOL_VERSION` | 2.0 | DYNAMIXEL プロトコルバージョン |
+| `DXL_BAUDRATE` | 1,000,000 bps | DYNAMIXEL 通信速度 |
+| `FALL_THRESHOLD_DEG` | 40.0° | 転倒判定閾値 |
+| `RPM_LIMIT` | 300 | モータ回転数制限 |
+
+### Mahony フィルタ定数 (imu_driver.h)
+
+| 定数名 | 値 | 説明 |
+|---|---|---|
+| `KP_MAHONY` | 2.0 | フィルタ比例ゲイン |
+| `KI_MAHONY` | 0.005 | フィルタ積分ゲイン |
+
+### その他の制御パラメータ (control_task.cpp 内)
+
+| パラメータ | 値 | 説明 |
+|---|---|---|
+| dt クランプ範囲 | 2ms〜50ms | 異常な Δt の除外 |
+| I 項上限 | `50 / |ki|` RPM | アンチワインドアップ制限 |
+| D 項フィルタ係数 | α = 0.2 | 1 次 IIR LPF の新値重み |
+
+---
+
+## 12. ビルドと書き込み
+
+### 12.1 環境構築
+
+1. [PlatformIO IDE](https://platformio.org/) を VSCode にインストール
+2. 本リポジトリを clone
+3. `firmware/bsl-balancer/` を VSCode で開く
+
+### 12.2 ビルド・書き込み
+
+```bash
+# ビルド
+cd firmware/bsl-balancer
+pio run
+
+# 書き込み（M5Stack Core2 を USB 接続した状態で）
+pio run --target upload
+
+# シリアルモニタ
+pio device monitor --baud 115200
+```
+
+### 12.3 事前準備
+
+書き込み前に DYNAMIXEL XL330 のボーレートを **1,000,000 bps** に設定しておく必要がある。設定には [m5core2_dynamixel_wizard](https://github.com/kim-xps12/m5core2_dynamixel_wizard) が利用できる。
+
+---
+
+## 13. レガシーコード (Arduino IDE 版) との差分
+
+`for_arduino_ide/for_arduino_ide.ino` は初期実装の単一ファイル版で、現在は**非推奨**。現行 PlatformIO 版との主要な差分:
+
+| 項目 | レガシー (Arduino IDE) | 現行 (PlatformIO) |
+|---|---|---|
+| ファイル構成 | 単一 .ino ファイル | マルチファイル (8 ファイル) |
+| 姿勢推定 | Kalman フィルタ (外部ライブラリ) | Mahony 相補フィルタ (自前実装) |
+| 制御周期 | 10ms (100Hz) | 5ms (200Hz) |
+| DYNAMIXEL ボーレート | 2,000,000 bps | 1,000,000 bps |
+| UART ピン | GPIO32(RX)/GPIO33(TX) | GPIO33(RX)/GPIO32(TX) ※逆 |
+| I2C 排他制御 | なし | `g_i2c_mutex` で排他制御 |
+| コマンドキュー | なし（グローバル変数直書き） | `g_cmd_queue` (FreeRTOS Queue) |
+| テレメトリ | なし | `g_telemetry_queue` + シリアル出力 |
+| WDT | なし | 1 秒タイムアウト |
+| アンチワインドアップ | `|I * Ki| > 200` で I=0 リセット | `I_acc` を連続的にクランプ |
+| D 項フィルタ | なし（生の微分値） | 1 次 IIR LPF (α=0.2) |
+| アバター | なし | TairinEye / TairinMouth |
+| パラメータ保存 | Preferences (NVS) 使用の痕跡あり | 未実装（リセットで消失） |
+
+### 主な改善点
+
+1. **スレッドセーフティ**: グローバル変数の直接共有から FreeRTOS キュー/ミューテックスへ
+2. **センサフュージョン**: 外部 Kalman ライブラリから軽量な Mahony フィルタへ
+3. **制御品質**: D 項フィルタ、連続アンチワインドアップ、2倍の制御レート
+4. **保守性**: マルチファイル構成、関心の分離
+5. **信頼性**: WDT による異常検知、I2C 排他制御
+
+---
+
+## 付録: テレメトリの読み方
+
+シリアルモニタで出力されるテレメトリの各フィールド:
+
+```
+>pitch:86.12    ← 推定ピッチ角 [deg]。86° 付近で安定が正常
+>rate:-0.34     ← ピッチ角速度 [deg/s]。0 付近で安定
+>rpm:5.0        ← モータ指令 RPM。正=前進方向
+>P:0.12         ← PID P項（偏差そのもの）
+>I:0.003        ← PID I項（積分蓄積値）
+>D:0.02         ← PID D項（フィルタ済み微分値）
+>loop_us:312    ← 制御ループ実行時間 [μs]。5000μs 以下が正常
+```

--- a/docs/plan-pid-velocity-control.md
+++ b/docs/plan-pid-velocity-control.md
@@ -1,0 +1,517 @@
+# PID ベース前後操縦制御の実装計画
+
+## Context
+
+現在のファームウェア (`firmware/bsl-balancer`) は単一 PID ループ（ピッチ偏差 → RPM）で倒立のみを行う。ファジィ制御器の移植（`jiggly-baking-quilt.md`）は Phase A〜C の長期計画であり、PID ベースで先に前後操縦を実現することで、ファジィ移植前の段階でも PS4 ゲームパッド操縦が可能になる。
+
+Web サーベイの結果、B-Robot (JJRobots)・Elegoo Tumbller・学術論文 (Velazquez et al.) などで実績のある **カスケード PI(速度) → PD(姿勢)** アーキテクチャを採用する。BSL-Balancer は DYNAMIXEL XL330 の Present Velocity レジスタ (addr=128) により実速度フィードバックが得られるため、エンコーダ無しの他プロジェクトより精度の高い閉ループ速度制御が可能。
+
+---
+
+## 制御アーキテクチャ
+
+```
+v_d (ゲームパッド or 0) ──┐
+                           ├─ v_err ──→ [速度 PI (25Hz)] ──→ theta_offset [deg]
+v_measured (DXL Sync Read)─┘                                   │ clamp(±5°)
+                                                               ↓
+                      pitch_target (86°) ──── − ──── effective_target
+                                                               │
+                                                               ↓
+pitch_filtered (Mahony) ──────────────────────→ [姿勢 PD (200Hz)] ──→ rpm_base
+pitch_rate_dps ──────────────────────────────→                          │
+                                                                        ↓
+                              yaw_rate_cmd ──→ [差動操舵] ──→ rpm_L, rpm_R
+                                                               │
+                                                         DXL setGoalVelocity
+```
+
+### 符号規約真理値表（Codex 指摘 #1 対応）
+
+本ファームウェアの符号規約:
+- `pitch_target = 86°`: 垂直姿勢
+- 前傾時: `pitch_filtered` が**減少**（85°方向）
+- `pitch_error = target - pitch_filtered`: 前傾で**正**
+- 正の RPM → 車輪前進 → 前傾を受け止めて復帰
+
+| 操作意図 | v_d | v_error | v_integral | theta_offset | effective_target | 物理効果 |
+|----------|-----|---------|------------|--------------|------------------|----------|
+| 前進加速 | +0.3 | +0.3 | 蓄積+ | +2° | 86−2 = **84°** | PIDが84°を目指す→前傾維持→前進 |
+| 後退加速 | −0.3 | −0.3 | 蓄積− | −2° | 86+2 = **88°** | PIDが88°を目指す→後傾維持→後退 |
+| 静止復帰 | 0 | −v | 減衰 | →0 | →86° | 元の倒立位置に復帰 |
+
+**重要**: `effective_target = pitch_target − theta_offset`（**減算**）。正の theta_offset で target を下げることにより前傾＝前進を実現する。
+
+### 数式
+
+**外側ループ（速度 PI, 25Hz, back-calculation anti-windup）**:
+```cpp
+v_error = v_d - v_measured;
+
+// 1. v_d 符号変化 → 積分器リセット
+if ((v_d > 0 && v_d_prev < 0) || (v_d < 0 && v_d_prev > 0)) v_integral = 0;
+
+// 2. v_d 非ゼロ→ゼロ遷移 → 積分器リセット
+if (fabsf(v_d) < 1e-4f && fabsf(v_d_prev) >= 1e-4f) v_integral = 0;
+
+// 3. 通常の積分蓄積
+v_integral += v_error * dt_speed;
+v_integral = clamp(v_integral, ±V_INTEGRAL_LIMIT);
+
+// 4. 出力計算 + back-calculation anti-windup
+float theta_raw = Kp_speed * v_error + Ki_speed * v_integral;
+theta_offset = clamp(theta_raw, ±THETA_OFFSET_MAX);
+if (theta_raw != theta_offset) {
+    // 出力がクランプされた → 積分器をクランプ後の出力と整合させる
+    v_integral = (theta_offset - Kp_speed * v_error) / Ki_speed;
+}
+
+// 5. 方向整合性チェック (v_error デッドバンド付き):
+//    減速中 (v_error<-0.05) なのに前傾指令 (theta_offset>0) → 積分器リセット
+//    デッドバンド 0.05 m/s により定常追従時のゼロ交差では非発動
+constexpr float V_ERR_DEADBAND = 0.05f;  // 定常ノイズを無視
+if (v_error * theta_offset < -1e-6f && fabsf(v_error) > V_ERR_DEADBAND) {
+    v_integral = 0.0f;
+    theta_offset = clamp(Kp_speed * v_error, ±THETA_OFFSET_MAX);
+}
+
+v_d_prev = v_d;
+```
+
+**5条件 anti-windup の効果**:
+- **条件1**: v_d 符号反転 → 即リセット
+- **条件2**: v_d 非ゼロ→ゼロ → 即リセット（前コマンドの積分残留を一掃。リセット後 PI ループが新たなドリフト抑制積分を蓄積）
+- **条件4 (back-calc)**: 出力クランプ時に積分器をクランプ値と整合するよう逆算
+- **条件5 (方向整合)**: v_error と theta_offset が逆符号（減速中なのに加速指令）→ 積分器リセット、比例項のみで出力
+- ドリフトホールド: 中立維持中は v_error≈0, theta_offset≈0 で条件5は非発動、通常通り積分蓄積
+
+**積分器リセット規則（Codex 第4回 #R6 対応、第8回 #R11 で修正）**:
+
+以下の**異常停止イベント**で `v_integral = 0`, `theta_offset = 0` に即時リセットする。
+これらは全て `SET_SPEED_ENABLED = false` コマンドとして送信し、制御タスク内で速度状態をクリアする:
+- `speed_enabled` が false に遷移した時（BtnB 長押し）
+- PS4 切断コールバック（`SET_SPEED_ENABLED=false` を送信）
+- L1 緊急停止（`SET_SPEED_ENABLED=false` を送信）
+- 転倒検知（制御タスク内で直接リセット）
+- 連続 Sync Read 失敗による自動無効化（制御タスク内で直接リセット）
+- **コマンド鮮度タイムアウト（R21→R24 で強化）**: 制御タスク内で最後の速度/ヨーコマンド受信からの経過時間を監視。**500ms** 以内に新しいコマンドが到着しない場合、`speed_enabled = false` に自動遷移し **v_d, yaw_rate_cmd, v_integral, theta_offset をすべてゼロ化**（UI タスク停止・BT コールバック欠落への防護）。UI タスクは **speed_enabled が true の間** 常に 50ms 周期でハートビートとして v_d + yaw_rate を送信する（PS4 接続時はスティック値、非接続時は v_d=0 / yaw=0）
+
+**デッドゾーン・符号変化・出力飽和の anti-windup（R14→R15→R16 で収束）**:
+
+速度 PI ループの疑似コード（上記）に全 anti-windup ロジックを統合済み:
+- **条件 1**: v_d 符号変化時に v_integral リセット（反転指令への即応答）
+- **条件 2**: v_d 非ゼロ→ゼロ遷移時に v_integral リセット（中立復帰の即応答）
+- **条件 3**: 出力飽和時に飽和深化方向の積分を停止（clamping anti-windup）
+- 中立維持中は v_d=0 を目標として PI ループがアクティブに動作し、ドリフト抑制のための積分器を新規に蓄積する
+
+**内側ループ（姿勢 PD, 200Hz）**: 速度制御有効時は真の PD（I 項ゼロ）
+```
+effective_target = pitch_target − theta_offset
+pitch_error = effective_target - pitch_filtered
+
+// D_val の定義 (R23→R26 で強化): 速度制御有効時は derivative-on-measurement
+// D_val = -pitch_rate_dps  (deg/s 単位、既存 Kd と整合。符号: 前傾速度で正)
+// theta_offset のステップ変化による微分キックを完全に回避
+// 速度制御無効時は既存の微分-on-error + LPF(α=0.2) を維持
+// Kd=0 (デフォルト) では D_val の寄与はゼロ
+
+if (speed_enabled) {
+    I_acc = 0;  // 遷移時・動作中ともに I_acc を完全クリア
+    rpm = Kp * P_val + Kd * D_val              // 真の PD（I 項なし）
+} else {
+    // speed_enabled→false 遷移時: D 状態をリセット（theta_offset ステップによる D スパイク防止）
+    if (speed_was_enabled) { preP = P_val; D_filtered = 0; }
+    I_acc += P_val * dt;
+    I_acc = clamp(I_acc, -i_limit, i_limit);
+    rpm = Kp * P_val + Ki * I_acc + Kd * D_val // 従来 PID
+}
+speed_was_enabled = speed_enabled;
+```
+
+**差動操舵（Phase S-B）**:
+```
+yaw_diff_rpm = yaw_rate_cmd * WHEEL_TRACK / (2 * WHEEL_R) * 60/(2π)
+rpm_L = clamp(rpm_base - yaw_diff_rpm, ±RPM_LIMIT)
+rpm_R = clamp(rpm_base + yaw_diff_rpm, ±RPM_LIMIT)
+```
+
+### 転倒検知の分離（Codex 指摘 #2 対応）
+
+転倒検知は `effective_target` ではなく **物理的な `pitch_target`** を基準とする:
+
+```cpp
+// 転倒検知: 物理バランス点からの絶対偏差で判定
+float fall_error = target - pitch_filtered;  // effective_target ではなく target
+if (fall_error < -FALL_THRESHOLD_DEG || FALL_THRESHOLD_DEG < fall_error) {
+    // 転倒処理: モータ停止 (Sync Write) + 速度制御状態リセット
+    driveMotors(0, 0);
+    I_acc = 0; theta_offset = 0; v_integral = 0;
+    ...
+}
+
+// PID 制御: 速度オフセット適用後の target で計算
+float pitch_error = effective_target - pitch_filtered;
+```
+
+### 初期パラメータ
+
+| パラメータ | 値 | 根拠 |
+|---|---|---|
+| Kp_speed | 5.0 deg/(m/s) | 0.1m/s 偏差で即座に 0.5° 補正。比例制動で中立復帰を高速化 |
+| Ki_speed | 2.0 deg/(m·s) | 0.1 m/s 誤差で 0.2 deg/s のチルト蓄積 |
+| THETA_OFFSET_MAX | 5.0° | ファジィ計画の θ_ref_max ≈ 0.10 rad ≈ 5.7° に近い |
+| V_INTEGRAL_LIMIT | 2.5 m·s | Ki*V_INT_LIM = 5 deg = THETA_OFFSET_MAX と一致 |
+| SPEED_LOOP_DIVIDER | 8 | 200/8 = 25 Hz (Tumbller と同じ) |
+| WHEEL_R | 0.029 m | 既存ファジィ計画の値 |
+| V_CMD_MAX | 0.3 m/s | 既存 Phase C 仕様 |
+
+**V_INTEGRAL_LIMIT 修正（Codex 指摘 #4 対応）**: 旧値 1.0 では Ki*limit=2° で THETA_OFFSET_MAX=5° に到達不可能。2.5 に修正し Ki*2.5=5°=THETA_OFFSET_MAX と整合。
+
+### ネスト積分器の回避（Codex 指摘 #4 対応、再レビュー #3 で強化）
+
+B-Robot は内側ループを PD（積分なし）、外側を PI とする。本計画でも速度制御有効時に I_acc を**ゼロクリア**し、PID 出力から Ki*I_acc 項を**除外**する（真の PD）。旧値の残留バイアスは発生しない。速度制御無効時は従来通り Ki=0.05 の PID が動作し、I_acc はゼロからの蓄積を再開する。
+
+---
+
+## Phase S-A: 速度フィードバック + 速度 PI ループ
+
+### 変更ファイル
+
+1. **`include/config.h`** — 速度制御定数追加 (WHEEL_R, Kp_speed, Ki_speed, THETA_OFFSET_MAX 等)
+2. **`include/shared_state.h`** — CtrlCommandType に `SET_SPEED_ENABLED`, `SET_VELOCITY_CMD` 等追加。TelemetryData に `v_measured`, `theta_offset`, `sync_read_us` 等追加
+3. **`src/control_task.cpp`** — DXL Sync Read 関数 `readWheelVelocity()` 追加。ループ内に速度 PI 計算を追加（25Hz 分周）。`effective_target = target - theta_offset` で既存 PID に接続。転倒検知を物理 target 基準に分離。モータ書込を Sync Write に移行
+4. **`src/ui_task.cpp`** — テレメトリ出力に `>v:`, `>theta_offset:` 等追加。BtnB 長押しで速度制御 ON/OFF トグル。**speed_enabled 中は 50ms 周期で v_d=0 / yaw=0 のハートビートコマンドを送信**（500ms デッドマンタイムアウト対応）
+
+### DXL Sync Read タイムアウト設計（Codex 指摘 #3 対応、再レビュー #1 で強化）
+
+Dynamixel2Arduino 0.8.1 の `syncRead(InfoSyncReadInst_t*, uint32_t timeout_ms)` は内部で各モータの Status Packet を順次待受けし、**各パケットに対して timeout_ms が適用される**。2 モータ構成では最悪 `2 × timeout_ms` の遅延が発生しうる。
+
+**注意（Codex 第4回レビュー #2 対応）**: API は `millis()` ベースのタイムアウトを使用するため、`timeout_ms=1` では tick 境界で即座に期限切れとなり正常パケットをドロップする。**最低 2ms が必要**。
+
+**タイムアウトを 2ms に設定**する:
+
+```cpp
+uint8_t recv_count = dxl.syncRead(&vel_sync_read, 2);  // 2ms timeout per status packet
+```
+
+- 正常時: 1Mbps で 4byte Status Packet ≈ 200μs × 2 = ~400μs
+- 最悪時: 2ms × 2 = 4ms (両方タイムアウト)
+
+失敗パス処理:
+- `recv_count < 2` (一方または両方未応答): `readWheelVelocity()` は NAN を返す
+- NAN 時: 前回の `v_measured` を保持（ドロップアウト保護）
+- 連続 N 回 (N=5, 200ms 相当) 失敗時: `speed_enabled` を自動無効化し、`v_integral` と `theta_offset` をリセット。テレメトリに警告出力
+- 最悪ケース: 4ms (2×2ms timeout) + 処理 5μs = ~4.0ms
+
+### モータ書込の非ブロック化（Codex #R8 対応、第6回で #R9 修正）
+
+既存の `setGoalVelocity()` は内部で `rxStatusPacket()` を**無条件に**呼び出す。SRL=1 に設定しても、ライブラリがパケットを待つ動作は変わらず 100ms/ID のタイムアウトが発生する（Codex 第6回で確認済み）。
+
+**対策**: `driveTire()` を **Sync Write** に完全置換する。Protocol 2.0 の Sync Write はステータス応答を要求しないため、ブロッキングが発生しない:
+
+```cpp
+// 静的バッファ（一度だけ初期化）
+static uint8_t goal_vel_buf_L[4];
+static uint8_t goal_vel_buf_R[4];
+static DYNAMIXEL::XELInfoSyncWrite_t vel_write_xels[2] = {
+    { goal_vel_buf_L, DXL_ID_L },
+    { goal_vel_buf_R, DXL_ID_R },
+};
+static DYNAMIXEL::InfoSyncWriteInst_t vel_sync_write = {
+    104,    // Goal Velocity address (XL330)
+    4,      // data length
+    vel_write_xels,
+    2,      // xel_count
+    true,   // is_info_changed
+    { nullptr, 0, 0, false }
+};
+
+static void driveMotors(int rpm_L, int rpm_R) {
+    // RPM → raw velocity value (1 raw = 0.229 RPM)
+    int32_t raw_L = (int32_t)(-rpm_L / 0.229f);  // 左モータ反転
+    int32_t raw_R = (int32_t)( rpm_R / 0.229f);
+    memcpy(goal_vel_buf_L, &raw_L, 4);
+    memcpy(goal_vel_buf_R, &raw_R, 4);
+    vel_sync_write.is_info_changed = true;  // バッファ更新をライブラリに通知（パケット再生成強制）
+    dxl.syncWrite(&vel_sync_write);         // 応答待ちなし
+}
+```
+
+既存の `driveTire(int rpm)` を `driveMotors(int rpm_L, int rpm_R)` に置換。差動操舵 (Phase S-B) にも対応する引数構成。
+
+### タイミングバジェット
+
+| 処理 | 所要時間 | 備考 |
+|------|---------|------|
+| 既存処理 (IMU+Mahony+PID) | ~330 μs | |
+| DXL Sync Write (Goal Velocity) | ~80 μs | 1 パケット送信、応答待ちなし |
+| DXL Sync Read (2ms/packet) | ~400 μs 正常 / 4000 μs 最悪 | 8 サイクルに 1 回 |
+| 速度 PI 計算 | ~5 μs | 8 サイクルに 1 回 |
+| テレメトリ | ~5 μs | |
+| **正常ケース合計** | **~820 μs** | **余裕 84%** |
+| **最悪ケース合計** | **~4420 μs** | **余裕 12%** (両モータ Sync Read タイムアウト時) |
+
+**I2C 競合との複合最悪ケース（R25 対応）**: IMU の I2C mutex 待ちが最大 2ms 発生しうるため、DXL Sync Read 4ms と重なると合計 6ms > 5ms 周期を超過する。対策として **予算ガード** を導入する:
+
+```cpp
+// 速度ループ実行サイクルで、IMU 読取後の経過時間を確認
+int64_t budget_us = esp_timer_get_time() - now_us;
+if (speed_divider_count >= SPEED_LOOP_DIVIDER && budget_us < 600) {
+    // 経過 600μs 未満 → 残り 4400μs 以上: Sync Read 最悪 4ms + 後処理 200μs に余裕
+    readWheelVelocity();
+} else if (speed_divider_count >= SPEED_LOOP_DIVIDER) {
+    // 経過 600μs 以上: Sync Read + 後処理で 5ms を超過する恐れ → スキップ
+    // v_measured は前回値を保持
+}
+```
+
+**予算ガードの閾値根拠**: Sync Read 最悪 4000μs + PID/Sync Write/テレメトリ ~200μs = 4200μs。600 + 4200 = 4800μs ≤ 5000μs 周期。閾値 600μs は acceptance 基準 (loop_us ≤ 4800μs) と整合する。
+
+**Phase S-A 検証で実測必須**: Sync Read の所要時間を **専用の `sync_read_us` テレメトリ** (`esp_timer_get_time()` で Sync Read 前後を計測) で個別に計測する。`loop_us` は全体の制御周期計測として別途監視する。
+
+合格基準（R22 対応: 最悪ケースも明示的 pass/fail）:
+- `sync_read_us`: 正常時 ≤ 1500μs / 片方タイムアウト時 ≤ 2500μs / 両方タイムアウト時 ≤ 4200μs
+  - 注: XL330 の Return Delay Time デフォルト = 250 (500μs/パケット)。`setup()` で Return Delay Time を 0 に設定するか、正常時閾値を 1500μs に引き上げる。本計画では閾値引き上げを採用
+- `loop_us` (速度ループ実行サイクル): 正常時 ≤ 2200μs (sync_read 1500 + 制御 330 + SW/PI/tel 370) / **最悪ケース ≤ 4800μs**
+- `loop_us` (非速度ループサイクル): ≤ 800μs (既存ベースライン)
+- **最悪ケース `loop_us` > 4800μs が正常動作中に発生**: 予算ガードの閾値を引き下げて Sync Read スキップを積極化する。それでも解決しない場合は Sync Read を制御ループ外（別タスク or DMA）に移動する設計変更を実施
+
+### 速度符号変換の詳細（Codex 再レビュー #2 対応）
+
+`readWheelVelocity()` の完全な変換式:
+
+```cpp
+// DXL Present Velocity: int32_t, 単位 0.229 RPM/raw
+// uint32_t 経由で合成し、未定義動作を回避 (buf[3]>=0x80 時の signed overflow 防止)
+static inline int32_t decodeInt32(const uint8_t* buf) {
+    uint32_t u = (uint32_t)buf[0] | ((uint32_t)buf[1] << 8)
+              | ((uint32_t)buf[2] << 16) | ((uint32_t)buf[3] << 24);
+    int32_t s;
+    memcpy(&s, &u, sizeof(s));
+    return s;
+}
+int32_t raw_L = decodeInt32(buf_L);
+int32_t raw_R = decodeInt32(buf_R);
+
+// 符号補正: driveTire() は左モータに -rpm を送信するため、
+// 前進時の Present Velocity は raw_L < 0, raw_R > 0
+// 車体速度 = (-raw_L + raw_R) / 2 → 前進時に正
+float avg_raw = (float)(-raw_L + raw_R) * 0.5f;
+
+// raw → RPM → rad/s → m/s
+float avg_rpm = avg_raw * DXL_VEL_UNIT;            // × 0.229 RPM/raw
+float avg_omega = avg_rpm * (2.0f * M_PI / 60.0f); // RPM → rad/s
+float v_measured = avg_omega * WHEEL_R;             // rad/s → m/s (× 0.029)
+```
+
+**符号検証アサーション** (デバッグ用、リリース時に削除):
+```cpp
+// 前進駆動中 (rpm_motor > 10): raw_L は負、raw_R は正であること
+if (rpm_motor > 10) {
+    assert(raw_L < 0 && raw_R > 0);  // 符号不一致なら即停止
+}
+```
+
+### 検証手順
+
+1. `pio run` ビルド成功
+2. **符号検証デスクテスト**（手持ち、速度制御 OFF）:
+   - 車輪を手で前方に回す → `v_measured > 0` 確認
+   - 車輪を手で後方に回す → `v_measured < 0` 確認
+   - `vel_L` (raw) が前進時に負、`vel_R` が正であること
+3. **Sync Read タイムアウトテスト**: モータ電源 OFF で `readWheelVelocity()` が NAN を返し、`sync_read_us` ≤ 4500μs であること。連続 5 回失敗で速度制御が自動無効化されること
+4. 倒立テスト（速度制御 OFF）: 既存動作の退行なし確認
+5. **速度制御符号検証**（手持ち、速度制御 ON）:
+   - 手で車輪を前方に回す → `theta_offset < 0` (ブレーキ方向) 確認
+   - テレメトリで `effective_target > pitch_target` (後傾方向) 確認
+6. 倒立テスト（速度制御 ON, v_d=0）: ドリフト抑制効果の確認
+7. **転倒検知テスト**: theta_offset=±5° 状態でロボットを傾けても、物理 target 基準 ±40° で正しく転倒検知すること
+8. **中立復帰テスト（走行中）**: 最大前進 (v_d=0.3) で数秒走行後にスティック中立 → `theta_offset` が 1 秒以内にブレーキ方向（負）に反転すること
+9. **中立復帰テスト（拘束中）**: ロボットを手で固定し v_d=0.3 を数秒指令（v_measured≈0）後にスティック中立 → `theta_offset` が即座に≈0 になること（前傾発進しないこと）
+10. **減速テスト**: v_d=0.3 で走行中に v_d=0.1 に減速 → `theta_offset` が 1 秒以内に減少方向に変化すること
+11. **反転テスト**: v_d=0.3 で走行中に v_d=-0.3 に反転 → `theta_offset` が即座にブレーキ/後退方向に反転すること
+
+---
+
+## Phase S-B: PS4 ゲームパッド統合
+
+### 変更ファイル
+
+1. **`platformio.ini`** — `PS4_Controller_Host@v1.1.0` 追加
+2. **`include/config.h`** — YAW_RATE_MAX, WHEEL_TRACK, PS4_DEADZONE, PS4_MAC_ADDRESS 追加
+3. **`src/main.cpp`** — `PS4.begin()` + 接続/切断コールバック登録
+4. **`src/ui_task.cpp`** — PS4 スティック読取 → CtrlCommand キュー送信
+5. **`src/control_task.cpp`** — `driveMotors()` に差動操舵ロジックを統合（Phase S-A で導入済みの Sync Write ヘルパーを使用）
+
+### スティックマッピング
+
+| スティック | 軸 | 出力 | 範囲 | デッドゾーン |
+|---|---|---|---|---|
+| 左 Y | 前後 | v_d [m/s] | ±0.3 | 13 (~10%) |
+| 右 X | 旋回 | yaw_rate [rad/s] | ±1.0 | 13 (~10%) |
+
+### 安全機構
+
+- **切断時**: コールバックで `SET_SPEED_ENABLED=false` + `SET_YAW_RATE_CMD=0` 送信 → 速度状態リセット → 静止バランスに復帰
+- **L1 ボタン**: `SET_SPEED_ENABLED=false` + `SET_YAW_RATE_CMD=0` 送信（速度状態を完全リセット）
+- **LCD 表示**: 接続状態表示
+
+### 検証手順
+
+1. SixaxisPairTool でペアリング → LCD に接続表示
+2. 左スティック前倒し → ロボット前進
+3. 右スティック左右 → その場旋回
+4. ニュートラル → 静止バランス復帰
+5. 切断 → 2 秒以内に停止
+6. L1 → 即時停止
+
+### 事前確認事項
+
+- `WHEEL_TRACK`（左右車輪間距離）を CAD または実機から計測して `config.h` に設定する
+- `PS4_MAC_ADDRESS` を ESP32 の実 MAC アドレスに設定する
+
+---
+
+## リスク分析
+
+| リスク | 確率 | 対策 |
+|--------|------|------|
+| 速度フィードバック符号ミス → 即転倒 | 中 | 符号真理値表 + デスクテスト 3 段階検証 |
+| 速度制御が姿勢制御を不安定化 | 中 | 内側 I 凍結 (PD化) + THETA_OFFSET_MAX=5° + Ki-only 開始 |
+| Sync Read タイムアウト超過 | 中 | 明示 2ms timeout + 連続失敗 5 回で自動無効化 |
+| 転倒検知閾値の速度オフセットによるドリフト | — | 転倒検知を物理 target 基準に分離（解決済み） |
+| ネスト積分器による不安定化 | — | 速度制御有効時に内側 I_acc 凍結（解決済み） |
+| BT が制御ループに干渉 | 低 | BT は Core 0 (UI)、制御は Core 1。キュー経由で疎結合 |
+| 積分巻き上げによる振動 | 中 | V_INTEGRAL_LIMIT + 転倒時リセット + 無効化時リセット |
+
+---
+
+## ブランチ戦略
+
+- `feat/fw-speed-phase-a` → `master` へ PR (firmware/bsl-balancer リポジトリ)
+- `feat/fw-speed-phase-b` → `master` へ PR (Phase S-A マージ後)
+
+## ファジィ計画との関係
+
+- Phase S-A の `readWheelVelocity()` は ファジィ Phase B の Sync Read と同一
+- Phase S-B の PS4 統合はファジィ Phase C と同一（差動操舵のベース関数が PID 出力かファジィ出力かの違いのみ）
+- ファジィ移植時にこれらのインフラをそのまま再利用可能
+
+---
+
+## Codex Adversarial Review 対応履歴
+
+### 初回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| 1 | 符号極性の誤り (`target + offset` で後傾指令) | HIGH | `effective_target = target − theta_offset` に修正。符号真理値表を追加 |
+| 2 | 転倒検知が effective_target 相対でドリフト | HIGH | 転倒検知を物理 `target` 基準に分離。PID 計算のみ `effective_target` 使用 |
+| 3 | Sync Read タイムアウト未指定 (API デフォルト 10ms) | HIGH | 明示 timeout 指定。連続 5 回失敗で自動無効化。最悪ケースバジェット追加 |
+| 4 | ネスト積分器 (内側 Ki + 外側 Ki) | MEDIUM | 速度制御有効時に内側 I_acc 凍結→PD化。V_INTEGRAL_LIMIT を 2.5 に修正 |
+
+### 再レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R1 | Sync Read per-motor timeout で 2×2ms=4ms の可能性 | HIGH | timeout を 1ms/packet に変更。最悪 2ms。実測検証ステップ追加 |
+| R2 | raw→v_measured の符号変換式が Phase S-A に不足 | HIGH | 完全な変換式とアサーションを Phase S-A に明記 |
+| R3 | 凍結 I_acc が RPM バイアスとして残留 | MEDIUM | I_acc をゼロクリア + Ki 項を出力から除外（真の PD）に変更 |
+
+### 第3回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R4 | buf[3]<<24 で signed overflow (未定義動作) | HIGH | uint32_t 経由合成 + memcpy で int32_t 変換。decodeInt32 ヘルパー追加 |
+| R5 | loop_us で Sync Read 単体を検証できない | MEDIUM | 専用 `sync_read_us` テレメトリ追加。閾値を個別に設定 |
+
+### 第4回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R6 | v_d=0 時に v_integral が残留し前傾維持 | HIGH | 全停止パス（disable/disconnect/L1/転倒/失敗/deadzone）で v_integral+theta_offset を即時リセット |
+| R7 | millis() ベース API で 1ms timeout は tick 境界で即期限切れ | HIGH | timeout を 2ms に変更。最悪 4ms。vTaskDelayUntil の自動回復で許容。連続失敗で自動無効化 |
+
+### 第5回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R8 | setGoalVelocity が 100ms/ID の応答待ちでブロック | HIGH | モータ書込を Sync Write に移行（応答不要） |
+
+### 第6回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R9 | SRL=1 でも setGoalVelocity は rxStatusPacket を無条件呼出し | HIGH | SRL 方式を撤回。dxl.syncWrite() による完全 Sync Write 移行に変更。driveMotors() ヘルパー実装 |
+
+### 第7回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R10 | is_info_changed が初回後 false → 古いパケット再送 | HIGH | driveMotors() で毎回 `is_info_changed = true` を設定してパケット再生成を強制 |
+
+### 第8回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R11 | デッドゾーン進入時の積分器リセットがゼロ速度ホールドを無効化 | HIGH | デッドゾーンでは v_d=0 のみ設定し積分器は維持。リセットは異常停止イベントに限定 |
+
+### 第9回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R12 | 飽和積分器の中立復帰に最大25秒（Kp_speed=0 で比例制動なし） | HIGH | Kp_speed を 0.0 → 5.0 に変更。比例項で即座にブレーキ方向補正 |
+| R13 | 切断/L1 が v_d=0 送信だけでは積分器リセットされない | HIGH | 切断/L1 では SET_SPEED_ENABLED=false を送信。制御タスクで速度状態を完全クリア |
+
+### 第10回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R14 | 飽和積分器が比例制動を打ち消し、中立でも前傾維持 | HIGH | →R15 で再修正 |
+
+### 第11回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R15 | v_measured≈0 (停止/拘束) 時に積分器が残留し中立で発進 | HIGH | →R16 に統合 |
+
+### 第12回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R16 | 飽和積分器が減速・反転指令に追従しない | HIGH | →R17 で back-calculation 方式に置換 |
+
+### 第13回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R17 | 同符号減速時にクランプ anti-windup が積分器を巻き戻せない | HIGH | back-calculation + 方向整合性チェック（条件5）で統合解決 |
+
+### 第14回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R18 | 同符号減速で非飽和化すると back-calculation が発動しない | HIGH | 条件5追加: v_error と theta_offset が逆符号なら v_integral=0 にリセットし比例項のみで出力 |
+
+### 第15回レビュー
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R19 | ソースコード未実装（計画フェーズなので想定通り） | HIGH | プラン承認後に Phase S-A で実装予定。プランレビューとしては非該当 |
+| R20 | 条件5が定常追従中のゼロ交差でリセット発動し PI 収束を妨げる | MEDIUM | V_ERR_DEADBAND=0.05 m/s を追加。定常ノイズでは非発動、明確な減速時のみ発動 |
+
+### 第16回レビュー (計画文書専用)
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R21 | UIタスク停止時にコマンドが陳腐化し無制御走行 | HIGH | コマンド鮮度タイムアウト 500ms 追加。超過で speed_enabled=false 自動遷移 |
+| R22 | 最悪ケース loop_us が pass/fail 基準に含まれない | HIGH | 最悪ケース loop_us ≤ 4800μs を明示的合格基準に追加 |
+| R23 | 内側 D 項 (D_val) の定義・符号・フィルタリングが未記載 | MEDIUM | →R26 で derivative-on-measurement に変更 |
+
+### 第17回レビュー (計画文書専用 #2)
+
+| # | 指摘 | 重要度 | 対応 |
+|---|------|--------|------|
+| R24 | デッドマンが velocity のみで yaw を放置 | HIGH | デッドマンを全駆動コマンド (v_d+yaw) に拡大。UIタスクは50ms周期でハートビート送信 |
+| R25 | I2C mutex 2ms + DXL timeout 4ms = 6ms > 5ms 周期 | HIGH | 予算ガード追加。IMU後の残り予算が2.5ms未満ならSyncReadをスキップ |
+| R26 | 微分-on-error が theta_offset ステップでキック | MEDIUM | 速度制御有効時は derivative-on-measurement (-pitch_rate_dps) に変更 |

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <Arduino.h>
+
+// M5Stack Core2 PORT A pin configuration
+constexpr uint8_t PIN_RX_SERVO = 33;
+constexpr uint8_t PIN_TX_SERVO = 32;
+
+// Default PID gains
+constexpr float DEFAULT_KP = 15.0f;
+constexpr float DEFAULT_KI = 0.05f;
+constexpr float DEFAULT_KD = 0.0f;
+constexpr float DEFAULT_PITCH_TARGET = 86.0f;
+
+// Control loop timing
+const TickType_t CTRL_PERIOD_TICKS = pdMS_TO_TICKS(5);  // 200Hz
+
+// DYNAMIXEL
+constexpr uint8_t DXL_ID_L = 0;
+constexpr uint8_t DXL_ID_R = 1;
+constexpr float DXL_PROTOCOL_VERSION = 2.0f;
+constexpr uint32_t DXL_BAUDRATE = 1000000;
+
+// Fall detection threshold [deg]
+constexpr float FALL_THRESHOLD_DEG = 40.0f;
+
+// Motor RPM limit
+constexpr int RPM_LIMIT = 300;

--- a/include/config.h
+++ b/include/config.h
@@ -25,3 +25,22 @@ constexpr float FALL_THRESHOLD_DEG = 40.0f;
 
 // Motor RPM limit
 constexpr int RPM_LIMIT = 300;
+
+// Speed control (outer loop)
+constexpr float WHEEL_R = 0.029f;
+constexpr float DEFAULT_KP_SPEED = 5.0f;
+constexpr float DEFAULT_KI_SPEED = 2.0f;
+constexpr float THETA_OFFSET_MAX = 5.0f;
+constexpr float V_INTEGRAL_LIMIT = 2.5f;
+constexpr uint8_t SPEED_LOOP_DIVIDER = 8;
+constexpr float WHEEL_BASE = 0.0669f;
+constexpr float V_CMD_MAX = 0.3f;
+constexpr float V_ERR_DEADBAND = 0.05f;
+constexpr uint32_t CMD_FRESHNESS_MS = 500;
+constexpr uint8_t SYNC_READ_FAIL_LIMIT = 5;
+
+// DXL Sync Read/Write addresses
+constexpr uint16_t DXL_ADDR_GOAL_VELOCITY = 104;
+constexpr uint16_t DXL_ADDR_PRESENT_VELOCITY = 128;
+constexpr uint16_t DXL_LEN_VELOCITY = 4;
+constexpr float DXL_VEL_UNIT = 0.229f;

--- a/include/imu_driver.h
+++ b/include/imu_driver.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <M5Unified.h>
+#include <freertos/semphr.h>
+
+class ImuDriver {
+public:
+    struct Data {
+        float pitch_deg;
+        float pitch_rate_dps;
+        bool valid;
+    };
+
+    void begin(SemaphoreHandle_t i2c_mutex);
+    Data update(float dt);
+
+    void calibrate(uint16_t n_samples = 500, float max_stddev_deg = 0.5f);
+
+    float pitchEstimate() const { return _pitch_est * RAD_TO_DEG; }
+
+private:
+    SemaphoreHandle_t _i2c_mutex = nullptr;
+
+    float _pitch_est = 0.0f;
+    float _gyro_bias = 0.0f;
+
+    static constexpr float KP_MAHONY = 2.0f;
+    static constexpr float KI_MAHONY = 0.005f;
+};

--- a/include/shared_state.h
+++ b/include/shared_state.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/semphr.h>
+
+enum class CtrlCommandType : uint8_t {
+    SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
+};
+
+struct CtrlCommand {
+    CtrlCommandType type;
+    float value;
+};
+
+struct TelemetryData {
+    float pitch_deg;
+    float pitch_rate_dps;
+    float rpm_cmd;
+    float P_term, I_term, D_term;
+    uint32_t loop_us;
+    bool fallen;
+};
+
+extern QueueHandle_t g_cmd_queue;
+extern QueueHandle_t g_telemetry_queue;
+extern SemaphoreHandle_t g_i2c_mutex;

--- a/include/shared_state.h
+++ b/include/shared_state.h
@@ -5,6 +5,11 @@
 
 enum class CtrlCommandType : uint8_t {
     SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
+    SET_SPEED_ENABLED,
+    SET_KP_SPEED,
+    SET_KI_SPEED,
+    SET_VELOCITY_CMD,
+    SET_YAW_RATE_CMD,
 };
 
 struct CtrlCommand {
@@ -19,6 +24,12 @@ struct TelemetryData {
     float P_term, I_term, D_term;
     uint32_t loop_us;
     bool fallen;
+    float v_measured;
+    float theta_offset;
+    float v_error;
+    float v_integral;
+    uint32_t sync_read_us;
+    bool speed_enabled;
 };
 
 extern QueueHandle_t g_cmd_queue;

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,8 +13,9 @@ platform = espressif32@6.10.0
 board = m5stack-core2
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
+build_flags =
+	-I include
+lib_deps =
 	robotis-git/Dynamixel2Arduino@^0.8.1
 	m5stack/M5Unified@^0.2.7
-	tkjelectronics/Kalman Filter Library@^1.0.2
 	meganetaaan/M5Stack-Avatar@^0.9.2

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:m5stack-core2]
-platform = espressif32
+platform = espressif32@6.10.0
 board = m5stack-core2
 framework = arduino
 monitor_speed = 115200

--- a/src/control_task.cpp
+++ b/src/control_task.cpp
@@ -1,0 +1,103 @@
+#include <Arduino.h>
+#include <Dynamixel2Arduino.h>
+#include <esp_task_wdt.h>
+#include <esp_timer.h>
+#include "config.h"
+#include "shared_state.h"
+#include "imu_driver.h"
+
+extern Dynamixel2Arduino dxl;
+extern ImuDriver imuDriver;
+
+static void driveTire(int rpm) {
+    dxl.setGoalVelocity(DXL_ID_L, -1 * rpm, UNIT_RPM);
+    dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
+}
+
+void controlLoopTask(void *pvParameters) {
+    esp_task_wdt_add(NULL);
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+
+    float kp = DEFAULT_KP;
+    float ki = DEFAULT_KI;
+    float kd = DEFAULT_KD;
+    float target = DEFAULT_PITCH_TARGET;
+    float I_acc = 0.0f;
+    float preP = 0.0f;
+    float D_filtered = 0.0f;
+    bool pid_active = false;
+    int64_t prev_us = 0;
+
+    while (true) {
+        esp_task_wdt_reset();
+        int64_t now_us = esp_timer_get_time();
+
+        CtrlCommand cmd;
+        while (xQueueReceive(g_cmd_queue, &cmd, 0) == pdTRUE) {
+            switch (cmd.type) {
+                case CtrlCommandType::SET_KP:           kp = cmd.value; break;
+                case CtrlCommandType::SET_KI:           ki = cmd.value; break;
+                case CtrlCommandType::SET_KD:           kd = cmd.value; break;
+                case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
+            }
+        }
+
+        float dt;
+        if (prev_us == 0) {
+            dt = 0.005f;
+        } else {
+            dt = (float)(now_us - prev_us) / 1000000.0f;
+            dt = constrain(dt, 0.002f, 0.050f);
+        }
+        prev_us = now_us;
+
+        auto imu = imuDriver.update(dt);
+        if (!imu.valid) {
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
+            continue;
+        }
+
+        float pitch_filtered = imu.pitch_deg;
+        float pitch_error = target - pitch_filtered;
+
+        if (pitch_error < -FALL_THRESHOLD_DEG || FALL_THRESHOLD_DEG < pitch_error) {
+            driveTire(0);
+            I_acc = 0.0f;
+            preP = 0.0f;
+            D_filtered = 0.0f;
+            pid_active = false;
+            TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
+                                 (uint32_t)(esp_timer_get_time() - now_us), true};
+            xQueueOverwrite(g_telemetry_queue, &tel);
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
+            continue;
+        }
+
+        float P_val = pitch_error;
+        I_acc += P_val * dt;
+        float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
+        I_acc = constrain(I_acc, -i_limit, i_limit);
+
+        float D_raw;
+        if (!pid_active) {
+            D_raw = 0.0f;
+            pid_active = true;
+        } else {
+            D_raw = (P_val - preP) / dt;
+        }
+        D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
+        float D_val = D_filtered;
+        preP = P_val;
+
+        float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
+        int rpm_motor = constrain((int)rpm_f, -RPM_LIMIT, RPM_LIMIT);
+        driveTire(rpm_motor);
+
+        uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
+        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)rpm_motor,
+                             P_val, I_acc, D_val, elapsed, false};
+        xQueueOverwrite(g_telemetry_queue, &tel);
+
+        vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
+    }
+}

--- a/src/control_task.cpp
+++ b/src/control_task.cpp
@@ -2,6 +2,8 @@
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
 #include <esp_timer.h>
+#include <cstring>
+#include <cmath>
 #include "config.h"
 #include "shared_state.h"
 #include "imu_driver.h"
@@ -9,11 +11,80 @@
 extern Dynamixel2Arduino dxl;
 extern ImuDriver imuDriver;
 
-static void driveTire(int rpm) {
-    dxl.setGoalVelocity(DXL_ID_L, -1 * rpm, UNIT_RPM);
-    dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
+// --- Sync Write for Goal Velocity (non-blocking) ---
+static uint8_t goal_vel_buf_L[DXL_LEN_VELOCITY];
+static uint8_t goal_vel_buf_R[DXL_LEN_VELOCITY];
+static DYNAMIXEL::XELInfoSyncWrite_t vel_write_xels[2] = {
+    {goal_vel_buf_L, DXL_ID_L},
+    {goal_vel_buf_R, DXL_ID_R},
+};
+static DYNAMIXEL::InfoSyncWriteInst_t vel_sync_write = {
+    DXL_ADDR_GOAL_VELOCITY,
+    DXL_LEN_VELOCITY,
+    vel_write_xels,
+    2,
+    true,
+    {nullptr, 0, 0, false}
+};
+
+static void driveMotors(int rpm_L, int rpm_R) {
+    int32_t raw_L = (int32_t)(-rpm_L / DXL_VEL_UNIT);
+    int32_t raw_R = (int32_t)( rpm_R / DXL_VEL_UNIT);
+    memcpy(goal_vel_buf_L, &raw_L, 4);
+    memcpy(goal_vel_buf_R, &raw_R, 4);
+    vel_sync_write.is_info_changed = true;
+    dxl.syncWrite(&vel_sync_write);
 }
 
+// --- Sync Read for Present Velocity ---
+static uint8_t vel_recv_buf_L[DXL_LEN_VELOCITY];
+static uint8_t vel_recv_buf_R[DXL_LEN_VELOCITY];
+static DYNAMIXEL::XELInfoSyncRead_t vel_read_xels[2] = {
+    {vel_recv_buf_L, DXL_ID_L, 0},
+    {vel_recv_buf_R, DXL_ID_R, 0},
+};
+static DYNAMIXEL::InfoSyncReadInst_t vel_sync_read = {
+    DXL_ADDR_PRESENT_VELOCITY,
+    DXL_LEN_VELOCITY,
+    vel_read_xels,
+    2,
+    true,
+    {nullptr, 0, 0, false}
+};
+
+static inline int32_t decodeInt32(const uint8_t* buf) {
+    uint32_t u = (uint32_t)buf[0] | ((uint32_t)buf[1] << 8)
+              | ((uint32_t)buf[2] << 16) | ((uint32_t)buf[3] << 24);
+    int32_t s;
+    memcpy(&s, &u, sizeof(s));
+    return s;
+}
+
+struct VelReadResult {
+    float v;
+    uint32_t elapsed_us;
+    bool valid;
+};
+
+static VelReadResult readWheelVelocity() {
+    VelReadResult r = {0, 0, false};
+    int64_t t0 = esp_timer_get_time();
+    uint8_t recv_count = dxl.syncRead(&vel_sync_read, 2);
+    r.elapsed_us = (uint32_t)(esp_timer_get_time() - t0);
+
+    if (recv_count < 2) return r;
+
+    int32_t raw_L = decodeInt32(vel_recv_buf_L);
+    int32_t raw_R = decodeInt32(vel_recv_buf_R);
+    float avg_raw = (float)(-raw_L + raw_R) * 0.5f;
+    float avg_rpm = avg_raw * DXL_VEL_UNIT;
+    float avg_omega = avg_rpm * (2.0f * M_PI / 60.0f);
+    r.v = avg_omega * WHEEL_R;
+    r.valid = true;
+    return r;
+}
+
+// --- Control Loop ---
 void controlLoopTask(void *pvParameters) {
     esp_task_wdt_add(NULL);
     TickType_t xLastWakeTime = xTaskGetTickCount();
@@ -28,10 +99,28 @@ void controlLoopTask(void *pvParameters) {
     bool pid_active = false;
     int64_t prev_us = 0;
 
+    // Speed control state
+    bool speed_enabled = false;
+    bool speed_was_enabled = false;
+    float kp_speed = DEFAULT_KP_SPEED;
+    float ki_speed = DEFAULT_KI_SPEED;
+    float v_d = 0.0f;
+    float yaw_rate_cmd = 0.0f;
+    float v_integral = 0.0f;
+    float theta_offset = 0.0f;
+    float v_measured = 0.0f;
+    float v_error_out = 0.0f;
+    float v_d_prev = 0.0f;
+    uint8_t speed_divider_count = 0;
+    uint8_t sync_read_fail_count = 0;
+    uint32_t last_cmd_ms = 0;
+    uint32_t last_sync_read_us = 0;
+
     while (true) {
         esp_task_wdt_reset();
         int64_t now_us = esp_timer_get_time();
 
+        // --- Command queue drain ---
         CtrlCommand cmd;
         while (xQueueReceive(g_cmd_queue, &cmd, 0) == pdTRUE) {
             switch (cmd.type) {
@@ -39,9 +128,39 @@ void controlLoopTask(void *pvParameters) {
                 case CtrlCommandType::SET_KI:           ki = cmd.value; break;
                 case CtrlCommandType::SET_KD:           kd = cmd.value; break;
                 case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
+                case CtrlCommandType::SET_SPEED_ENABLED:
+                    speed_enabled = (cmd.value > 0.5f);
+                    if (speed_enabled) {
+                        last_cmd_ms = millis();
+                        sync_read_fail_count = 0;
+                    } else {
+                        v_d = 0; yaw_rate_cmd = 0;
+                        v_integral = 0; theta_offset = 0;
+                        sync_read_fail_count = 0;
+                    }
+                    break;
+                case CtrlCommandType::SET_KP_SPEED:     kp_speed = cmd.value; break;
+                case CtrlCommandType::SET_KI_SPEED:     ki_speed = cmd.value; break;
+                case CtrlCommandType::SET_VELOCITY_CMD:
+                    v_d = constrain(cmd.value, -V_CMD_MAX, V_CMD_MAX);
+                    last_cmd_ms = millis();
+                    break;
+                case CtrlCommandType::SET_YAW_RATE_CMD:
+                    yaw_rate_cmd = cmd.value;
+                    last_cmd_ms = millis();
+                    break;
             }
         }
 
+        // --- Command freshness timeout ---
+        if (speed_enabled && (millis() - last_cmd_ms > CMD_FRESHNESS_MS)) {
+            speed_enabled = false;
+            v_d = 0; yaw_rate_cmd = 0;
+            v_integral = 0; theta_offset = 0;
+            sync_read_fail_count = 0;
+        }
+
+        // --- dt calculation ---
         float dt;
         if (prev_us == 0) {
             dt = 0.005f;
@@ -51,6 +170,7 @@ void controlLoopTask(void *pvParameters) {
         }
         prev_us = now_us;
 
+        // --- IMU update ---
         auto imu = imuDriver.update(dt);
         if (!imu.valid) {
             vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
@@ -58,44 +178,151 @@ void controlLoopTask(void *pvParameters) {
         }
 
         float pitch_filtered = imu.pitch_deg;
-        float pitch_error = target - pitch_filtered;
 
-        if (pitch_error < -FALL_THRESHOLD_DEG || FALL_THRESHOLD_DEG < pitch_error) {
-            driveTire(0);
+        // --- Fall detection (based on physical target, not effective_target) ---
+        float fall_error = target - pitch_filtered;
+        if (fall_error < -FALL_THRESHOLD_DEG || FALL_THRESHOLD_DEG < fall_error) {
+            driveMotors(0, 0);
             I_acc = 0.0f;
             preP = 0.0f;
             D_filtered = 0.0f;
             pid_active = false;
+            speed_enabled = false;
+            v_d = 0.0f;
+            yaw_rate_cmd = 0.0f;
+            theta_offset = 0.0f;
+            v_integral = 0.0f;
+            v_measured = 0.0f;
+            v_d_prev = 0.0f;
+            speed_divider_count = 0;
+            sync_read_fail_count = 0;
             TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
-                                 (uint32_t)(esp_timer_get_time() - now_us), true};
+                                 (uint32_t)(esp_timer_get_time() - now_us), true,
+                                 0, 0, 0, 0, 0, speed_enabled};
             xQueueOverwrite(g_telemetry_queue, &tel);
             vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
+        // --- Speed control outer loop (25 Hz) ---
+        speed_divider_count++;
+        if (speed_enabled && speed_divider_count >= SPEED_LOOP_DIVIDER) {
+            speed_divider_count = 0;
+            float dt_speed = dt * SPEED_LOOP_DIVIDER;
+
+            // Budget guard: only run Sync Read if enough time remains
+            int64_t budget_us = esp_timer_get_time() - now_us;
+            if (budget_us < 600) {
+                VelReadResult vr = readWheelVelocity();
+                last_sync_read_us = vr.elapsed_us;
+                if (vr.valid) {
+                    v_measured = vr.v;
+                    sync_read_fail_count = 0;
+                } else {
+                    sync_read_fail_count++;
+                }
+            }
+            if (sync_read_fail_count >= SYNC_READ_FAIL_LIMIT) {
+                speed_enabled = false;
+                v_d = 0; yaw_rate_cmd = 0;
+                v_integral = 0; theta_offset = 0;
+                sync_read_fail_count = 0;
+            }
+
+            // Speed PI with 5-condition anti-windup
+            float v_error = v_d - v_measured;
+            v_error_out = v_error;
+
+            // Condition 1: v_d sign change → reset
+            if ((v_d > 0 && v_d_prev < 0) || (v_d < 0 && v_d_prev > 0)) {
+                v_integral = 0.0f;
+            }
+            // Condition 2: v_d nonzero→zero transition → reset
+            if (fabsf(v_d) < 1e-4f && fabsf(v_d_prev) >= 1e-4f) {
+                v_integral = 0.0f;
+            }
+
+            // Condition 3: normal integration
+            v_integral += v_error * dt_speed;
+            v_integral = constrain(v_integral, -V_INTEGRAL_LIMIT, V_INTEGRAL_LIMIT);
+
+            // Condition 4: output + back-calculation anti-windup
+            float theta_raw = kp_speed * v_error + ki_speed * v_integral;
+            theta_offset = constrain(theta_raw, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
+            if (theta_raw != theta_offset && fabsf(ki_speed) > 1e-6f) {
+                v_integral = (theta_offset - kp_speed * v_error) / ki_speed;
+            }
+
+            // Condition 5: direction consistency (with deadband)
+            if (v_error * theta_offset < -1e-6f && fabsf(v_error) > V_ERR_DEADBAND) {
+                v_integral = 0.0f;
+                theta_offset = constrain(kp_speed * v_error, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
+            }
+
+            v_d_prev = v_d;
+        }
+
+        if (!speed_enabled) {
+            theta_offset = 0.0f;
+            v_integral = 0.0f;
+        }
+
+        // --- Inner PID/PD loop ---
+        float effective_target = target - theta_offset;
+        float pitch_error = effective_target - pitch_filtered;
+
         float P_val = pitch_error;
-        I_acc += P_val * dt;
-        float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
-        I_acc = constrain(I_acc, -i_limit, i_limit);
+
+        // Reset derivative state on speed→non-speed transition BEFORE D computation
+        if (!speed_enabled && speed_was_enabled) {
+            preP = P_val;
+            D_filtered = 0.0f;
+        }
 
         float D_raw;
         if (!pid_active) {
             D_raw = 0.0f;
             pid_active = true;
         } else {
-            D_raw = (P_val - preP) / dt;
+            if (speed_enabled) {
+                // Derivative-on-measurement to avoid theta_offset step kicks
+                D_raw = -imu.pitch_rate_dps;
+            } else {
+                // Derivative-on-error (existing behavior)
+                D_raw = (P_val - preP) / dt;
+            }
         }
         D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
         float D_val = D_filtered;
         preP = P_val;
 
-        float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
-        int rpm_motor = constrain((int)rpm_f, -RPM_LIMIT, RPM_LIMIT);
-        driveTire(rpm_motor);
+        float rpm_f;
+        if (speed_enabled) {
+            I_acc = 0.0f;
+            rpm_f = kp * P_val + kd * D_val;
+        } else {
+            I_acc += P_val * dt;
+            float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
+            I_acc = constrain(I_acc, -i_limit, i_limit);
+            rpm_f = kp * P_val + ki * I_acc + kd * D_val;
+        }
+        speed_was_enabled = speed_enabled;
+
+        // Yaw differential mixing: turn_ff = 0.5 * yaw_rate * track_width / wheel_r
+        float yaw_rpm = 0.0f;
+        if (speed_enabled && fabsf(yaw_rate_cmd) > 1e-4f) {
+            float yaw_omega = yaw_rate_cmd * WHEEL_BASE / (2.0f * WHEEL_R);
+            yaw_rpm = yaw_omega * (60.0f / (2.0f * M_PI));
+        }
+        int rpm_L = constrain((int)(rpm_f - yaw_rpm), -RPM_LIMIT, RPM_LIMIT);
+        int rpm_R = constrain((int)(rpm_f + yaw_rpm), -RPM_LIMIT, RPM_LIMIT);
+        driveMotors(rpm_L, rpm_R);
 
         uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
-        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)rpm_motor,
-                             P_val, I_acc, D_val, elapsed, false};
+        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)((rpm_L + rpm_R) / 2),
+                             P_val, I_acc, D_val, elapsed, false,
+                             v_measured, theta_offset, v_error_out, v_integral,
+                             last_sync_read_us, speed_enabled};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
         vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);

--- a/src/imu_driver.cpp
+++ b/src/imu_driver.cpp
@@ -1,0 +1,70 @@
+#include "imu_driver.h"
+#include <cmath>
+
+void ImuDriver::begin(SemaphoreHandle_t i2c_mutex) {
+    _i2c_mutex = i2c_mutex;
+    _pitch_est = 0.0f;
+    _gyro_bias = 0.0f;
+}
+
+ImuDriver::Data ImuDriver::update(float dt) {
+    Data result = {0, 0, false};
+
+    if (xSemaphoreTake(_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) {
+        return result;
+    }
+    auto mask = M5.Imu.update();
+    xSemaphoreGive(_i2c_mutex);
+
+    if (!mask) return result;
+
+    auto imu = M5.Imu.getImuData();
+
+    float ay = imu.accel.y;
+    float az = imu.accel.z;
+    float gx = imu.gyro.x * DEG_TO_RAD;
+
+    float accel_pitch = atan2f(ay, az);
+    float error = accel_pitch - _pitch_est;
+
+    _gyro_bias += KI_MAHONY * error * dt;
+
+    float gyro_corrected = gx + KP_MAHONY * error + _gyro_bias;
+
+    _pitch_est += gyro_corrected * dt;
+
+    result.pitch_deg = _pitch_est * RAD_TO_DEG;
+    result.pitch_rate_dps = gyro_corrected * RAD_TO_DEG;
+    result.valid = true;
+    return result;
+}
+
+void ImuDriver::calibrate(uint16_t n_samples, float max_stddev_deg) {
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+
+    for (uint16_t i = 0; i < n_samples; i++) {
+        if (xSemaphoreTake(_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            M5.Imu.update();
+            xSemaphoreGive(_i2c_mutex);
+        }
+        auto imu = M5.Imu.getImuData();
+        float pitch = atan2f(imu.accel.y, imu.accel.z) * RAD_TO_DEG;
+        sum += pitch;
+        sum_sq += pitch * pitch;
+        vTaskDelay(pdMS_TO_TICKS(2));
+    }
+
+    float mean = sum / n_samples;
+    float variance = (sum_sq / n_samples) - (mean * mean);
+    float stddev = sqrtf(fabsf(variance));
+
+    if (stddev > max_stddev_deg) {
+        Serial.printf("IMU cal: stddev=%.2f > %.2f (vibration?)\n", stddev, max_stddev_deg);
+    }
+
+    _pitch_est = mean * DEG_TO_RAD;
+    _gyro_bias = 0.0f;
+
+    Serial.printf("IMU cal: pitch=%.2f deg, stddev=%.3f (%d samples)\n", mean, stddev, n_samples);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,13 +272,13 @@ void setup(){
   
   // RTOS Task Settings
   const uint32_t MEMORY_STACK = 8192;
-  const UBaseType_t PRIORIRY_SPIN_MAIN = 5;
-  const BaseType_t ID_CORE_CTRL_MAIN = 0;
-  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORIRY_SPIN_MAIN, NULL, ID_CORE_CTRL_MAIN);
-  
-  const UBaseType_t PRIORIRY_SPIN_SUB = 2;
-  const BaseType_t ID_CORE_CTRL_SUB = 1;
-  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORIRY_SPIN_SUB,  NULL, ID_CORE_CTRL_SUB);
+  const UBaseType_t PRIORITY_CTRL = 20;
+  const BaseType_t CORE_CTRL = 1;
+  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORITY_CTRL, NULL, CORE_CTRL);
+
+  const UBaseType_t PRIORITY_UI = 3;
+  const BaseType_t CORE_UI = 0;
+  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORITY_UI,   NULL, CORE_UI);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,6 @@
 #include <Arduino.h>
 
 #include <M5Unified.h>
-#include <Avatar.h>
-
-#include "TairinEye.h"
-#include "TairinMouth.h"
 
 #include <Kalman.h>
 #include <Preferences.h>
@@ -15,28 +11,11 @@ HardwareSerial& DXL_SERIAL = Serial1;
 #define DEBUG_SERIAL Serial
 //#define ENABLE_DEBUG_PRINT
 
-
-using namespace m5avatar;
-Avatar avatar;
-Face* tairinFace;
-
-Face* createTairinFace(){
-  Face* f;
-  f = new Face(
-    new tairinMouth(50, 90, 4, 60),
-    new tairinEye(8, false),
-    new tairinEye(8, true),
-    new Eyeblow(32, 0, false),
-    new Eyeblow(32, 0, true)
-  );
-  return f;
-}
-
 // M5Stack Core2 PORT A pin configuration
 const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
-// Contoller Params. 
+// Contoller Params.
 const TickType_t xPeriodMs = 10;  // [milli sec]
 float Kp = 50.0;
 float Ki = 1.0;
@@ -51,8 +30,6 @@ float preP = 0.0;
 
 // Kalman filter Params.
 Kalman kalman;
-float accX, accY, accZ;
-float gyroX, gyroY, gyroZ;
 
 // Contoller Values
 unsigned long previousTimestamp = 0;
@@ -66,18 +43,22 @@ const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl;//(DXL_SERIAL);
 
+// I2C bus mutex (IMU on control task vs AXP192/touch on UI task)
+SemaphoreHandle_t g_i2c_mutex = nullptr;
 
-float getPitch(){
-  M5.Imu.getAccelData(&accX, &accY, &accZ);
-  float pitch = atan2(accY, accZ) * RAD_TO_DEG; //[deg]
-  return pitch;
-}
+struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
 
-
-float getPitchDot() {
-  M5.Imu.getGyroData(&gyroX, &gyroY, &gyroZ);
-  float pitch_dot = gyroX;
-  return pitch_dot;  //[deg/sec]
+ImuData readImuBurst() {
+    ImuData r = {0, 0, false};
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) return r;
+    auto mask = M5.Imu.update();
+    xSemaphoreGive(g_i2c_mutex);
+    if (!mask) return r;
+    auto d = M5.Imu.getImuData();
+    r.pitch_deg = atan2f(d.accel.y, d.accel.z) * RAD_TO_DEG;
+    r.pitch_rate_dps = d.gyro.x;
+    r.valid = true;
+    return r;
 }
 
 
@@ -101,9 +82,13 @@ void calcPID(){
   currentTimestamp = micros();
   elapsedTime = currentTimestamp - previousTimestamp;
   previousTimestamp = currentTimestamp;
-  
+
   float dt = (float)xPeriodMs /1000; // [sec]
-  float pitch_kalman = kalman.getAngle(getPitch(), getPitchDot(), dt);
+
+  ImuData imu = readImuBurst();
+  if (!imu.valid) return;
+
+  float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
   float pitch_dot_kalman = kalman.getRate();
 
   float pitch_error = pitch_target - pitch_kalman;
@@ -125,7 +110,7 @@ void calcPID(){
   if (200 < abs(I * Ki)) {
     I = 0;
   }
-    
+
   // Calclate Motor Output
   int rpm_motor = Kp * P + Ki * I + Kd * D;
   rpm_motor = constrain(rpm_motor, -300, 300);
@@ -140,7 +125,7 @@ void drawButton(const char* label, int x, int y, float value) {
 
   M5.Display.drawRect(x+200, y, 50, 30, WHITE);
   M5.Display.drawString("+", x+200+20, y, 2);
-  
+
   // draw label and value
   M5.Display.setCursor(x+70, y+5);
   M5.Display.print(label);
@@ -155,9 +140,12 @@ void drawCtrlPanel(){
   drawButton("Ki", 20, 110, Ki);
   drawButton("Kd", 20, 150, Kd);
 
-  M5.Display.setCursor(20, 190);
-  int batteryPercentage = M5.Power.getBatteryLevel();
-  M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+  if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    int batteryPercentage = M5.Power.getBatteryLevel();
+    xSemaphoreGive(g_i2c_mutex);
+    M5.Display.setCursor(20, 190);
+    M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+  }
 }
 
 
@@ -202,30 +190,26 @@ void controlLoopTask(void *pvParameters) {
 
 bool enShowCtrlPanel = false;
 void uiLoopTask(void *pvParameters){
-  
-  TickType_t xLastWakeTime = xTaskGetTickCount();  
-  while(true){
-    M5.update();
 
-    //draw avatar face
-    if (M5.BtnA.wasPressed()) {
-      avatar.resume();
+  TickType_t xLastWakeTime = xTaskGetTickCount();
+  while(true){
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+      M5.update();
+      xSemaphoreGive(g_i2c_mutex);
     }
 
     // show tuning panel
     if (M5.BtnB.wasPressed()) {
       if (enShowCtrlPanel) {
         enShowCtrlPanel = false;
-        avatar.resume();
         M5.Lcd.clear();
       } else {
         enShowCtrlPanel = true;
-        avatar.suspend();
         M5.Lcd.clear();
         drawCtrlPanel();
       }
     }
-    
+
     if (enShowCtrlPanel) {
       bool isReleased = true;
         if (M5.Touch.getCount()>0 && isReleased) {
@@ -242,19 +226,23 @@ void setup(){
 
   DEBUG_SERIAL.begin(115200);
 
-  // M5 Settings
-  M5.begin();
+  // M5 Settings (selective init: disable unused peripherals)
+  auto cfg = M5.config();
+  cfg.internal_rtc = false;
+  cfg.internal_mic = false;
+  cfg.internal_spk = false;
+  cfg.internal_imu = true;
+  M5.begin(cfg);
   M5.Lcd.fillScreen(BLACK);
   M5.Lcd.setTextSize(2);
   M5.Lcd.setCursor(0, 0);
-  M5.Imu.init();
-  // M5.Imu.setAccelFsr(M5.Imu.AFS_2G);
-  // M5.Imu.setGyroFsr(M5.Imu.GFS_250DPS);
 
-  // M5 avatar Settings
-  tairinFace = createTairinFace();
-  avatar.setFace(tairinFace);
-  avatar.init();
+  // Avatar disabled during architecture improvement (Phase 3-8)
+  // Will be re-enabled in Phase 9 after all improvements are stable.
+
+  // I2C mutex
+  g_i2c_mutex = xSemaphoreCreateMutex();
+  configASSERT(g_i2c_mutex != nullptr);
 
   // DYNAMIXEL Settings
   DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
@@ -264,17 +252,22 @@ void setup(){
   dxl.ping(DXL_ID_L);
   dxl.ping(DXL_ID_R);
   dxl.torqueOff(DXL_ID_L);  // Turn off torque when configuring items in EEPROM area
-  dxl.torqueOff(DXL_ID_R); 
+  dxl.torqueOff(DXL_ID_R);
   dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
   dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
   dxl.torqueOn(DXL_ID_L);
   dxl.torqueOn(DXL_ID_R);
 
-  // Kalman filter Setting
-  kalman.setAngle(getPitch());
-  
-  // WDT: I2C ハング等で制御ループが停止した場合にシステムリセット
-  esp_task_wdt_init(1, true);  // 1秒タイムアウト、panic=true
+  // Kalman filter Setting (initial pitch via burst read)
+  ImuData imu_init = readImuBurst();
+  if (imu_init.valid) {
+    kalman.setAngle(imu_init.pitch_deg);
+  } else {
+    kalman.setAngle(86.0);
+  }
+
+  // WDT
+  esp_task_wdt_init(1, true);
 
   // RTOS Task Settings
   const uint32_t MEMORY_STACK = 8192;
@@ -289,5 +282,5 @@ void setup(){
 
 
 void loop(){
-  
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,272 +1,22 @@
 #include <Arduino.h>
-
 #include <M5Unified.h>
-
-#include <Preferences.h>
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
-#include <esp_timer.h>
+#include "config.h"
+#include "shared_state.h"
 #include "imu_driver.h"
 
-HardwareSerial& DXL_SERIAL = Serial1;
-
-// M5Stack Core2 PORT A pin configuration
-const uint8_t PIN_RX_SERVO = 33;
-const uint8_t PIN_TX_SERVO = 32;
-
-// Default controller params
-const float DEFAULT_KP = 15.0f;
-const float DEFAULT_KI = 0.05f;
-const float DEFAULT_KD = 0.0f;
-const float DEFAULT_PITCH_TARGET = 86.0f;
-const TickType_t CTRL_PERIOD_TICKS = pdMS_TO_TICKS(5);  // 200Hz
-
-// DYNAMIXEL Params.
-const uint8_t DXL_ID_L = 0;
-const uint8_t DXL_ID_R = 1;
-const float DXL_PROTOCOL_VERSION = 2.0;
-
+// Global instances
 Dynamixel2Arduino dxl;
 ImuDriver imuDriver;
 
-// I2C bus mutex
-SemaphoreHandle_t g_i2c_mutex = nullptr;
-
-// --- Inter-task communication ---
-
-enum class CtrlCommandType : uint8_t {
-    SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
-};
-struct CtrlCommand { CtrlCommandType type; float value; };
-
-struct TelemetryData {
-    float pitch_deg;
-    float pitch_rate_dps;
-    float rpm_cmd;
-    float P_term, I_term, D_term;
-    uint32_t loop_us;
-    bool fallen;
-};
-
 QueueHandle_t g_cmd_queue = nullptr;
 QueueHandle_t g_telemetry_queue = nullptr;
+SemaphoreHandle_t g_i2c_mutex = nullptr;
 
-// --- Motor drive ---
-
-void driveTire(int rpm) {
-    dxl.setGoalVelocity(DXL_ID_L, -1 * rpm, UNIT_RPM);
-    dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
-}
-
-// --- Control task ---
-
-void controlLoopTask(void *pvParameters) {
-    esp_task_wdt_add(NULL);
-    TickType_t xLastWakeTime = xTaskGetTickCount();
-
-    float kp = DEFAULT_KP;
-    float ki = DEFAULT_KI;
-    float kd = DEFAULT_KD;
-    float target = DEFAULT_PITCH_TARGET;
-    float I_acc = 0.0f;
-    float preP = 0.0f;
-    float D_filtered = 0.0f;
-    bool pid_active = false;
-    int64_t prev_us = 0;
-
-    while (true) {
-        esp_task_wdt_reset();
-        int64_t now_us = esp_timer_get_time();
-
-        // Drain pending commands (non-blocking)
-        CtrlCommand cmd;
-        while (xQueueReceive(g_cmd_queue, &cmd, 0) == pdTRUE) {
-            switch (cmd.type) {
-                case CtrlCommandType::SET_KP:           kp = cmd.value; break;
-                case CtrlCommandType::SET_KI:           ki = cmd.value; break;
-                case CtrlCommandType::SET_KD:           kd = cmd.value; break;
-                case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
-            }
-        }
-
-        // Compute dt from actual elapsed time
-        float dt;
-        if (prev_us == 0) {
-            dt = 0.010f;
-        } else {
-            dt = (float)(now_us - prev_us) / 1000000.0f;
-            dt = constrain(dt, 0.002f, 0.050f);
-        }
-        prev_us = now_us;
-
-        // IMU read + Mahony fusion
-        auto imu = imuDriver.update(dt);
-        if (!imu.valid) {
-            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
-            continue;
-        }
-
-        float pitch_filtered = imu.pitch_deg;
-
-        float pitch_error = target - pitch_filtered;
-
-        // Fall detection
-        if (pitch_error < -40.0f || 40.0f < pitch_error) {
-            driveTire(0);
-            I_acc = 0.0f;
-            preP = 0.0f;
-            D_filtered = 0.0f;
-            pid_active = false;
-            TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
-                                 (uint32_t)(esp_timer_get_time() - now_us), true};
-            xQueueOverwrite(g_telemetry_queue, &tel);
-            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
-            continue;
-        }
-
-        // PID
-        float P_val = pitch_error;
-        I_acc += P_val * dt;
-        float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
-        I_acc = constrain(I_acc, -i_limit, i_limit);
-
-        float D_raw;
-        if (!pid_active) {
-            D_raw = 0.0f;
-            pid_active = true;
-        } else {
-            D_raw = (P_val - preP) / dt;
-        }
-        // Low-pass filter on D term (alpha=0.2: heavy smoothing)
-        D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
-        float D_val = D_filtered;
-        preP = P_val;
-
-        float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
-        int rpm_motor = constrain((int)rpm_f, -300, 300);
-        driveTire(rpm_motor);
-
-        // Telemetry (non-blocking overwrite)
-        uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
-        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)rpm_motor,
-                             P_val, I_acc, D_val, elapsed, false};
-        xQueueOverwrite(g_telemetry_queue, &tel);
-
-        vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
-    }
-}
-
-// --- UI helpers ---
-
-void drawButton(const char* label, int x, int y, float value) {
-    M5.Display.drawRect(x, y, 50, 30, WHITE);
-    M5.Display.drawString("-", x + 20, y, 2);
-    M5.Display.drawRect(x + 200, y, 50, 30, WHITE);
-    M5.Display.drawString("+", x + 200 + 20, y, 2);
-    M5.Display.setCursor(x + 70, y + 5);
-    M5.Display.print(label);
-    M5.Display.print(": ");
-    M5.Display.println(value, 1);
-}
-
-// --- UI task ---
-
-static float ui_kp = DEFAULT_KP;
-static float ui_ki = DEFAULT_KI;
-static float ui_kd = DEFAULT_KD;
-static float ui_target = DEFAULT_PITCH_TARGET;
-bool enShowCtrlPanel = false;
-
-void drawCtrlPanel() {
-    drawButton("Ref", 20, 30, ui_target);
-    drawButton("Kp", 20, 70, ui_kp);
-    drawButton("Ki", 20, 110, ui_ki);
-    drawButton("Kd", 20, 150, ui_kd);
-
-    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-        int batteryPercentage = M5.Power.getBatteryLevel();
-        xSemaphoreGive(g_i2c_mutex);
-        M5.Display.setCursor(20, 190);
-        M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
-    }
-}
-
-void handleCtrlPanelTouched() {
-    auto pos = M5.Touch.getDetail();
-    if (!pos.wasPressed()) return;
-
-    CtrlCommand cmd;
-    bool send = true;
-
-    if (pos.y >= 30 && pos.y < 60) {
-        if (pos.x >= 15 && pos.x < 120)      ui_target -= 0.2f;
-        else if (pos.x >= 220 && pos.x < 270) ui_target += 0.2f;
-        else send = false;
-        if (send) { cmd = {CtrlCommandType::SET_PITCH_TARGET, ui_target}; drawButton("Ref", 20, 30, ui_target); }
-    }
-    else if (pos.y >= 70 && pos.y < 100) {
-        if (pos.x >= 15 && pos.x < 120)      ui_kp -= 0.2f;
-        else if (pos.x >= 220 && pos.x < 270) ui_kp += 0.2f;
-        else send = false;
-        if (send) { cmd = {CtrlCommandType::SET_KP, ui_kp}; drawButton("Kp", 20, 70, ui_kp); }
-    }
-    else if (pos.y >= 110 && pos.y < 140) {
-        if (pos.x >= 15 && pos.x < 120)      ui_ki -= 0.2f;
-        else if (pos.x >= 220 && pos.x < 270) ui_ki += 0.2f;
-        else send = false;
-        if (send) { cmd = {CtrlCommandType::SET_KI, ui_ki}; drawButton("Ki", 20, 110, ui_ki); }
-    }
-    else if (pos.y >= 150 && pos.y < 180) {
-        if (pos.x >= 15 && pos.x < 120)      ui_kd -= 0.2f;
-        else if (pos.x >= 220 && pos.x < 270) ui_kd += 0.2f;
-        else send = false;
-        if (send) { cmd = {CtrlCommandType::SET_KD, ui_kd}; drawButton("Kd", 20, 150, ui_kd); }
-    }
-    else {
-        send = false;
-    }
-
-    if (send) xQueueSend(g_cmd_queue, &cmd, 0);
-}
-
-void uiLoopTask(void *pvParameters) {
-    TickType_t xLastWakeTime = xTaskGetTickCount();
-    uint32_t last_telemetry_ms = 0;
-
-    while (true) {
-        if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-            M5.update();
-            xSemaphoreGive(g_i2c_mutex);
-        }
-
-        // Toggle tuning panel
-        if (M5.BtnB.wasPressed()) {
-            enShowCtrlPanel = !enShowCtrlPanel;
-            M5.Lcd.clear();
-            if (enShowCtrlPanel) drawCtrlPanel();
-        }
-
-        if (enShowCtrlPanel) {
-            handleCtrlPanelTouched();
-        }
-
-        // Telemetry output via Serial (10Hz)
-        uint32_t now_ms = millis();
-        TelemetryData tel;
-        if (now_ms - last_telemetry_ms >= 100) {
-            if (xQueuePeek(g_telemetry_queue, &tel, 0) == pdTRUE) {
-                last_telemetry_ms = now_ms;
-                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n",
-                              tel.pitch_deg, tel.pitch_rate_dps, tel.rpm_cmd,
-                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us);
-            }
-        }
-
-        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(50));
-    }
-}
-
-// --- Setup ---
+// Task entry points (defined in control_task.cpp / ui_task.cpp)
+extern void controlLoopTask(void *pvParameters);
+extern void uiLoopTask(void *pvParameters);
 
 void setup() {
     Serial.begin(115200);
@@ -291,12 +41,12 @@ void setup() {
     configASSERT(g_cmd_queue != nullptr);
     configASSERT(g_telemetry_queue != nullptr);
 
-    // DYNAMIXEL Settings
-    DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
-    dxl = Dynamixel2Arduino(DXL_SERIAL);
-    dxl.begin(1000000);
+    // DYNAMIXEL
+    HardwareSerial& dxl_serial = Serial1;
+    dxl_serial.begin(DXL_BAUDRATE, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
+    dxl = Dynamixel2Arduino(dxl_serial);
+    dxl.begin(DXL_BAUDRATE);
     dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
-
     if (!dxl.ping(DXL_ID_L)) { M5.Lcd.println("DXL L ping FAIL"); }
     if (!dxl.ping(DXL_ID_R)) { M5.Lcd.println("DXL R ping FAIL"); }
     dxl.torqueOff(DXL_ID_L);
@@ -306,7 +56,7 @@ void setup() {
     dxl.torqueOn(DXL_ID_L);
     dxl.torqueOn(DXL_ID_R);
 
-    // IMU driver init + calibration
+    // IMU
     imuDriver.begin(g_i2c_mutex);
     M5.Lcd.println("Calibrating...");
     imuDriver.calibrate(500, 0.5f);
@@ -316,9 +66,9 @@ void setup() {
     esp_task_wdt_init(1, true);
 
     // RTOS Tasks
-    const uint32_t MEMORY_STACK = 8192;
-    xTaskCreatePinnedToCore(controlLoopTask, "Control", MEMORY_STACK, NULL, 20, NULL, 1);
-    xTaskCreatePinnedToCore(uiLoopTask,      "UI",      MEMORY_STACK, NULL, 3,  NULL, 0);
+    const uint32_t STACK_SIZE = 8192;
+    xTaskCreatePinnedToCore(controlLoopTask, "Control", STACK_SIZE, NULL, 20, NULL, 1);
+    xTaskCreatePinnedToCore(uiLoopTask,      "UI",      STACK_SIZE, NULL, 3,  NULL, 0);
 }
 
 void loop() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ const float DEFAULT_KP = 15.0f;
 const float DEFAULT_KI = 0.05f;
 const float DEFAULT_KD = 0.0f;
 const float DEFAULT_PITCH_TARGET = 86.0f;
-const TickType_t xPeriodMs = 10;
+const TickType_t CTRL_PERIOD_TICKS = pdMS_TO_TICKS(5);  // 200Hz
 
 // DYNAMIXEL Params.
 const uint8_t DXL_ID_L = 0;
@@ -102,7 +102,7 @@ void controlLoopTask(void *pvParameters) {
         // IMU read + Mahony fusion
         auto imu = imuDriver.update(dt);
         if (!imu.valid) {
-            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
@@ -120,7 +120,7 @@ void controlLoopTask(void *pvParameters) {
             TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
                                  (uint32_t)(esp_timer_get_time() - now_us), true};
             xQueueOverwrite(g_telemetry_queue, &tel);
-            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
@@ -152,7 +152,7 @@ void controlLoopTask(void *pvParameters) {
                              P_val, I_acc, D_val, elapsed, false};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
-        vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+        vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <Kalman.h>
 #include <Preferences.h>
 #include <Dynamixel2Arduino.h>
+#include <esp_task_wdt.h>
 
 HardwareSerial& DXL_SERIAL = Serial1;
 #define DEBUG_SERIAL Serial
@@ -188,9 +189,11 @@ void handleCtrlPanelTouched(){
 
 
 void controlLoopTask(void *pvParameters) {
+    esp_task_wdt_add(NULL);
     TickType_t xLastWakeTime = xTaskGetTickCount();
 
     while(true) {
+      esp_task_wdt_reset();
       calcPID();
       vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
     }
@@ -270,6 +273,9 @@ void setup(){
   // Kalman filter Setting
   kalman.setAngle(getPitch());
   
+  // WDT: I2C ハング等で制御ループが停止した場合にシステムリセット
+  esp_task_wdt_init(1, true);  // 1秒タイムアウト、panic=true
+
   // RTOS Task Settings
   const uint32_t MEMORY_STACK = 8192;
   const UBaseType_t PRIORITY_CTRL = 20;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,11 @@
 
 #include <M5Unified.h>
 
-#include <Kalman.h>
 #include <Preferences.h>
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
 #include <esp_timer.h>
+#include "imu_driver.h"
 
 HardwareSerial& DXL_SERIAL = Serial1;
 
@@ -15,9 +15,9 @@ const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
 // Default controller params
-const float DEFAULT_KP = 50.0f;
-const float DEFAULT_KI = 1.0f;
-const float DEFAULT_KD = 1.0f;
+const float DEFAULT_KP = 15.0f;
+const float DEFAULT_KI = 0.05f;
+const float DEFAULT_KD = 0.0f;
 const float DEFAULT_PITCH_TARGET = 86.0f;
 const TickType_t xPeriodMs = 10;
 
@@ -27,7 +27,7 @@ const uint8_t DXL_ID_R = 1;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 Dynamixel2Arduino dxl;
-Kalman kalman;
+ImuDriver imuDriver;
 
 // I2C bus mutex
 SemaphoreHandle_t g_i2c_mutex = nullptr;
@@ -51,23 +51,6 @@ struct TelemetryData {
 QueueHandle_t g_cmd_queue = nullptr;
 QueueHandle_t g_telemetry_queue = nullptr;
 
-// --- IMU burst read ---
-
-struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
-
-ImuData readImuBurst() {
-    ImuData r = {0, 0, false};
-    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(2)) != pdTRUE) return r;
-    auto mask = M5.Imu.update();
-    xSemaphoreGive(g_i2c_mutex);
-    if (!mask) return r;
-    auto d = M5.Imu.getImuData();
-    r.pitch_deg = atan2f(d.accel.y, d.accel.z) * RAD_TO_DEG;
-    r.pitch_rate_dps = d.gyro.x;
-    r.valid = true;
-    return r;
-}
-
 // --- Motor drive ---
 
 void driveTire(int rpm) {
@@ -87,6 +70,8 @@ void controlLoopTask(void *pvParameters) {
     float target = DEFAULT_PITCH_TARGET;
     float I_acc = 0.0f;
     float preP = 0.0f;
+    float D_filtered = 0.0f;
+    bool pid_active = false;
     int64_t prev_us = 0;
 
     while (true) {
@@ -114,23 +99,25 @@ void controlLoopTask(void *pvParameters) {
         }
         prev_us = now_us;
 
-        // IMU burst read
-        ImuData imu = readImuBurst();
+        // IMU read + Mahony fusion
+        auto imu = imuDriver.update(dt);
         if (!imu.valid) {
             vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
             continue;
         }
 
-        float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
+        float pitch_filtered = imu.pitch_deg;
 
-        float pitch_error = target - pitch_kalman;
+        float pitch_error = target - pitch_filtered;
 
         // Fall detection
         if (pitch_error < -40.0f || 40.0f < pitch_error) {
             driveTire(0);
             I_acc = 0.0f;
             preP = 0.0f;
-            TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, 0, 0, 0, 0,
+            D_filtered = 0.0f;
+            pid_active = false;
+            TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
                                  (uint32_t)(esp_timer_get_time() - now_us), true};
             xQueueOverwrite(g_telemetry_queue, &tel);
             vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
@@ -140,9 +127,19 @@ void controlLoopTask(void *pvParameters) {
         // PID
         float P_val = pitch_error;
         I_acc += P_val * dt;
-        float i_limit = 200.0f / (fabsf(ki) + 1e-6f);
+        float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
         I_acc = constrain(I_acc, -i_limit, i_limit);
-        float D_val = (P_val - preP) / dt;
+
+        float D_raw;
+        if (!pid_active) {
+            D_raw = 0.0f;
+            pid_active = true;
+        } else {
+            D_raw = (P_val - preP) / dt;
+        }
+        // Low-pass filter on D term (alpha=0.2: heavy smoothing)
+        D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
+        float D_val = D_filtered;
         preP = P_val;
 
         float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
@@ -151,7 +148,7 @@ void controlLoopTask(void *pvParameters) {
 
         // Telemetry (non-blocking overwrite)
         uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
-        TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, (float)rpm_motor,
+        TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)rpm_motor,
                              P_val, I_acc, D_val, elapsed, false};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
@@ -309,9 +306,11 @@ void setup() {
     dxl.torqueOn(DXL_ID_L);
     dxl.torqueOn(DXL_ID_R);
 
-    // Kalman filter init
-    ImuData imu_init = readImuBurst();
-    kalman.setAngle(imu_init.valid ? imu_init.pitch_deg : DEFAULT_PITCH_TARGET);
+    // IMU driver init + calibration
+    imuDriver.begin(g_i2c_mutex);
+    M5.Lcd.println("Calibrating...");
+    imuDriver.calibrate(500, 0.5f);
+    M5.Lcd.println("Ready!");
 
     // WDT
     esp_task_wdt_init(1, true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,45 +6,52 @@
 #include <Preferences.h>
 #include <Dynamixel2Arduino.h>
 #include <esp_task_wdt.h>
+#include <esp_timer.h>
 
 HardwareSerial& DXL_SERIAL = Serial1;
-#define DEBUG_SERIAL Serial
-//#define ENABLE_DEBUG_PRINT
 
 // M5Stack Core2 PORT A pin configuration
 const uint8_t PIN_RX_SERVO = 33;
 const uint8_t PIN_TX_SERVO = 32;
 
-// Contoller Params.
-const TickType_t xPeriodMs = 10;  // [milli sec]
-float Kp = 50.0;
-float Ki = 1.0;
-float Kd = 1.0;
-
-float pitch_target = 86.0; //[deg]
-
-float P = 0.0;
-float I = 0.0;
-float D = 0.0;
-float preP = 0.0;
-
-// Kalman filter Params.
-Kalman kalman;
-
-// Contoller Values
-unsigned long previousTimestamp = 0;
-unsigned long currentTimestamp = 0;
-unsigned long elapsedTime = 0;
+// Default controller params
+const float DEFAULT_KP = 50.0f;
+const float DEFAULT_KI = 1.0f;
+const float DEFAULT_KD = 1.0f;
+const float DEFAULT_PITCH_TARGET = 86.0f;
+const TickType_t xPeriodMs = 10;
 
 // DYNAMIXEL Params.
 const uint8_t DXL_ID_L = 0;
 const uint8_t DXL_ID_R = 1;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
-Dynamixel2Arduino dxl;//(DXL_SERIAL);
+Dynamixel2Arduino dxl;
+Kalman kalman;
 
-// I2C bus mutex (IMU on control task vs AXP192/touch on UI task)
+// I2C bus mutex
 SemaphoreHandle_t g_i2c_mutex = nullptr;
+
+// --- Inter-task communication ---
+
+enum class CtrlCommandType : uint8_t {
+    SET_PITCH_TARGET, SET_KP, SET_KI, SET_KD,
+};
+struct CtrlCommand { CtrlCommandType type; float value; };
+
+struct TelemetryData {
+    float pitch_deg;
+    float pitch_rate_dps;
+    float rpm_cmd;
+    float P_term, I_term, D_term;
+    uint32_t loop_us;
+    bool fallen;
+};
+
+QueueHandle_t g_cmd_queue = nullptr;
+QueueHandle_t g_telemetry_queue = nullptr;
+
+// --- IMU burst read ---
 
 struct ImuData { float pitch_deg; float pitch_rate_dps; bool valid; };
 
@@ -61,226 +68,259 @@ ImuData readImuBurst() {
     return r;
 }
 
+// --- Motor drive ---
 
 void driveTire(int rpm) {
-
-  // Set Goal Velocity using RPM
-  dxl.setGoalVelocity(DXL_ID_L, -1*rpm, UNIT_RPM);
-  dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
-
-  #ifdef ENABLE_DEBUG_PRINT
-  DEBUG_SERIAL.print("Present Velocity(rpm)--L : ");
-  DEBUG_SERIAL.print(dxl.getPresentVelocity(DXL_ID_L, UNIT_RPM));
-  DEBUG_SERIAL.print(", R : ");
-  DEBUG_SERIAL.println(dxl.getPresentVelocity(DXL_ID_R, UNIT_RPM));
-  #endif
+    dxl.setGoalVelocity(DXL_ID_L, -1 * rpm, UNIT_RPM);
+    dxl.setGoalVelocity(DXL_ID_R, rpm, UNIT_RPM);
 }
 
-
-void calcPID(){
-
-  currentTimestamp = micros();
-  elapsedTime = currentTimestamp - previousTimestamp;
-  previousTimestamp = currentTimestamp;
-
-  float dt = (float)xPeriodMs /1000; // [sec]
-
-  ImuData imu = readImuBurst();
-  if (!imu.valid) return;
-
-  float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
-  float pitch_dot_kalman = kalman.getRate();
-
-  float pitch_error = pitch_target - pitch_kalman;
-
-  if(pitch_error < -40 || 40 < pitch_error) {
-    driveTire(0);
-    P = 0;
-    I = 0;
-    D = 0;
-    return;
-  }
-
-  P = pitch_target - pitch_kalman;
-  I += P * dt;
-  D = (P - preP) / dt;
-  preP = P;
-
-  // anti windup
-  if (200 < abs(I * Ki)) {
-    I = 0;
-  }
-
-  // Calclate Motor Output
-  int rpm_motor = Kp * P + Ki * I + Kd * D;
-  rpm_motor = constrain(rpm_motor, -300, 300);
-  driveTire(rpm_motor);
-}
-
-
-void drawButton(const char* label, int x, int y, float value) {
-  // draw button
-  M5.Display.drawRect(x, y, 50, 30, WHITE);
-  M5.Display.drawString("-", x+20, y, 2);
-
-  M5.Display.drawRect(x+200, y, 50, 30, WHITE);
-  M5.Display.drawString("+", x+200+20, y, 2);
-
-  // draw label and value
-  M5.Display.setCursor(x+70, y+5);
-  M5.Display.print(label);
-  M5.Display.print(": ");
-  M5.Display.println(value, 1);
-}
-
-
-void drawCtrlPanel(){
-  drawButton("Ref", 20, 30, pitch_target);
-  drawButton("Kp", 20, 70, Kp);
-  drawButton("Ki", 20, 110, Ki);
-  drawButton("Kd", 20, 150, Kd);
-
-  if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-    int batteryPercentage = M5.Power.getBatteryLevel();
-    xSemaphoreGive(g_i2c_mutex);
-    M5.Display.setCursor(20, 190);
-    M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
-  }
-}
-
-
-void handleCtrlPanelTouched(){
-
-  auto pos = M5.Touch.getDetail();
-
-  if (pos.y >= 30 && pos.y < 60) { // Target
-    if (pos.x >= 15 && pos.x < 120) pitch_target -= 0.2;
-      else if (pos.x >= 220 && pos.x < 270) pitch_target += 0.2;
-      drawButton("Ref", 20, 30, pitch_target);
-  }
-  else if (pos.y >= 70 && pos.y < 100) {
-    if (pos.x >= 15 && pos.x < 120) Kp -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Kp += 0.2;
-    drawButton("Kp", 20, 70, Kp);
-  }
-  else if (pos.y >= 110 && pos.y < 140) { // Ki
-    if (pos.x >= 15 && pos.x < 120) Ki -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Ki += 0.2;
-    drawButton("Ki", 20, 110, Ki);
-  }
-  else if (pos.y >= 150 && pos.y < 180) { // Kd
-    if (pos.x >= 15 && pos.x < 120) Kd -= 0.2;
-    else if (pos.x >= 220 && pos.x < 270) Kd += 0.2;
-    drawButton("Kd", 20, 150, Kd);
-  }
-}
-
+// --- Control task ---
 
 void controlLoopTask(void *pvParameters) {
     esp_task_wdt_add(NULL);
     TickType_t xLastWakeTime = xTaskGetTickCount();
 
-    while(true) {
-      esp_task_wdt_reset();
-      calcPID();
-      vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
-    }
-}
+    float kp = DEFAULT_KP;
+    float ki = DEFAULT_KI;
+    float kd = DEFAULT_KD;
+    float target = DEFAULT_PITCH_TARGET;
+    float I_acc = 0.0f;
+    float preP = 0.0f;
+    int64_t prev_us = 0;
 
+    while (true) {
+        esp_task_wdt_reset();
+        int64_t now_us = esp_timer_get_time();
 
-bool enShowCtrlPanel = false;
-void uiLoopTask(void *pvParameters){
-
-  TickType_t xLastWakeTime = xTaskGetTickCount();
-  while(true){
-    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-      M5.update();
-      xSemaphoreGive(g_i2c_mutex);
-    }
-
-    // show tuning panel
-    if (M5.BtnB.wasPressed()) {
-      if (enShowCtrlPanel) {
-        enShowCtrlPanel = false;
-        M5.Lcd.clear();
-      } else {
-        enShowCtrlPanel = true;
-        M5.Lcd.clear();
-        drawCtrlPanel();
-      }
-    }
-
-    if (enShowCtrlPanel) {
-      bool isReleased = true;
-        if (M5.Touch.getCount()>0 && isReleased) {
-          isReleased = false;
-          handleCtrlPanelTouched();
+        // Drain pending commands (non-blocking)
+        CtrlCommand cmd;
+        while (xQueueReceive(g_cmd_queue, &cmd, 0) == pdTRUE) {
+            switch (cmd.type) {
+                case CtrlCommandType::SET_KP:           kp = cmd.value; break;
+                case CtrlCommandType::SET_KI:           ki = cmd.value; break;
+                case CtrlCommandType::SET_KD:           kd = cmd.value; break;
+                case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
+            }
         }
-      }
-    vTaskDelayUntil(&xLastWakeTime, xPeriodMs*5);
-  }
+
+        // Compute dt from actual elapsed time
+        float dt;
+        if (prev_us == 0) {
+            dt = 0.010f;
+        } else {
+            dt = (float)(now_us - prev_us) / 1000000.0f;
+            dt = constrain(dt, 0.002f, 0.050f);
+        }
+        prev_us = now_us;
+
+        // IMU burst read
+        ImuData imu = readImuBurst();
+        if (!imu.valid) {
+            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            continue;
+        }
+
+        float pitch_kalman = kalman.getAngle(imu.pitch_deg, imu.pitch_rate_dps, dt);
+
+        float pitch_error = target - pitch_kalman;
+
+        // Fall detection
+        if (pitch_error < -40.0f || 40.0f < pitch_error) {
+            driveTire(0);
+            I_acc = 0.0f;
+            preP = 0.0f;
+            TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, 0, 0, 0, 0,
+                                 (uint32_t)(esp_timer_get_time() - now_us), true};
+            xQueueOverwrite(g_telemetry_queue, &tel);
+            vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+            continue;
+        }
+
+        // PID
+        float P_val = pitch_error;
+        I_acc += P_val * dt;
+        float i_limit = 200.0f / (fabsf(ki) + 1e-6f);
+        I_acc = constrain(I_acc, -i_limit, i_limit);
+        float D_val = (P_val - preP) / dt;
+        preP = P_val;
+
+        float rpm_f = kp * P_val + ki * I_acc + kd * D_val;
+        int rpm_motor = constrain((int)rpm_f, -300, 300);
+        driveTire(rpm_motor);
+
+        // Telemetry (non-blocking overwrite)
+        uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
+        TelemetryData tel = {pitch_kalman, imu.pitch_rate_dps, (float)rpm_motor,
+                             P_val, I_acc, D_val, elapsed, false};
+        xQueueOverwrite(g_telemetry_queue, &tel);
+
+        vTaskDelayUntil(&xLastWakeTime, xPeriodMs);
+    }
 }
 
+// --- UI helpers ---
 
-void setup(){
-
-  DEBUG_SERIAL.begin(115200);
-
-  // M5 Settings (selective init: disable unused peripherals)
-  auto cfg = M5.config();
-  cfg.internal_rtc = false;
-  cfg.internal_mic = false;
-  cfg.internal_spk = false;
-  cfg.internal_imu = true;
-  M5.begin(cfg);
-  M5.Lcd.fillScreen(BLACK);
-  M5.Lcd.setTextSize(2);
-  M5.Lcd.setCursor(0, 0);
-
-  // Avatar disabled during architecture improvement (Phase 3-8)
-  // Will be re-enabled in Phase 9 after all improvements are stable.
-
-  // I2C mutex
-  g_i2c_mutex = xSemaphoreCreateMutex();
-  configASSERT(g_i2c_mutex != nullptr);
-
-  // DYNAMIXEL Settings
-  DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
-  dxl = Dynamixel2Arduino(DXL_SERIAL);
-  dxl.begin(1000000);  // DYNAMIXEL baudrate.
-  dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
-  dxl.ping(DXL_ID_L);
-  dxl.ping(DXL_ID_R);
-  dxl.torqueOff(DXL_ID_L);  // Turn off torque when configuring items in EEPROM area
-  dxl.torqueOff(DXL_ID_R);
-  dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
-  dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
-  dxl.torqueOn(DXL_ID_L);
-  dxl.torqueOn(DXL_ID_R);
-
-  // Kalman filter Setting (initial pitch via burst read)
-  ImuData imu_init = readImuBurst();
-  if (imu_init.valid) {
-    kalman.setAngle(imu_init.pitch_deg);
-  } else {
-    kalman.setAngle(86.0);
-  }
-
-  // WDT
-  esp_task_wdt_init(1, true);
-
-  // RTOS Task Settings
-  const uint32_t MEMORY_STACK = 8192;
-  const UBaseType_t PRIORITY_CTRL = 20;
-  const BaseType_t CORE_CTRL = 1;
-  xTaskCreatePinnedToCore(controlLoopTask, "Control Loop Task", MEMORY_STACK, NULL, PRIORITY_CTRL, NULL, CORE_CTRL);
-
-  const UBaseType_t PRIORITY_UI = 3;
-  const BaseType_t CORE_UI = 0;
-  xTaskCreatePinnedToCore(uiLoopTask,      "UI Loop Task",      MEMORY_STACK, NULL, PRIORITY_UI,   NULL, CORE_UI);
+void drawButton(const char* label, int x, int y, float value) {
+    M5.Display.drawRect(x, y, 50, 30, WHITE);
+    M5.Display.drawString("-", x + 20, y, 2);
+    M5.Display.drawRect(x + 200, y, 50, 30, WHITE);
+    M5.Display.drawString("+", x + 200 + 20, y, 2);
+    M5.Display.setCursor(x + 70, y + 5);
+    M5.Display.print(label);
+    M5.Display.print(": ");
+    M5.Display.println(value, 1);
 }
 
+// --- UI task ---
 
-void loop(){
+static float ui_kp = DEFAULT_KP;
+static float ui_ki = DEFAULT_KI;
+static float ui_kd = DEFAULT_KD;
+static float ui_target = DEFAULT_PITCH_TARGET;
+bool enShowCtrlPanel = false;
 
+void drawCtrlPanel() {
+    drawButton("Ref", 20, 30, ui_target);
+    drawButton("Kp", 20, 70, ui_kp);
+    drawButton("Ki", 20, 110, ui_ki);
+    drawButton("Kd", 20, 150, ui_kd);
+
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        int batteryPercentage = M5.Power.getBatteryLevel();
+        xSemaphoreGive(g_i2c_mutex);
+        M5.Display.setCursor(20, 190);
+        M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+    }
+}
+
+void handleCtrlPanelTouched() {
+    auto pos = M5.Touch.getDetail();
+    if (!pos.wasPressed()) return;
+
+    CtrlCommand cmd;
+    bool send = true;
+
+    if (pos.y >= 30 && pos.y < 60) {
+        if (pos.x >= 15 && pos.x < 120)      ui_target -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_target += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_PITCH_TARGET, ui_target}; drawButton("Ref", 20, 30, ui_target); }
+    }
+    else if (pos.y >= 70 && pos.y < 100) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kp -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kp += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KP, ui_kp}; drawButton("Kp", 20, 70, ui_kp); }
+    }
+    else if (pos.y >= 110 && pos.y < 140) {
+        if (pos.x >= 15 && pos.x < 120)      ui_ki -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_ki += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KI, ui_ki}; drawButton("Ki", 20, 110, ui_ki); }
+    }
+    else if (pos.y >= 150 && pos.y < 180) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kd -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kd += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KD, ui_kd}; drawButton("Kd", 20, 150, ui_kd); }
+    }
+    else {
+        send = false;
+    }
+
+    if (send) xQueueSend(g_cmd_queue, &cmd, 0);
+}
+
+void uiLoopTask(void *pvParameters) {
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    uint32_t last_telemetry_ms = 0;
+
+    while (true) {
+        if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            M5.update();
+            xSemaphoreGive(g_i2c_mutex);
+        }
+
+        // Toggle tuning panel
+        if (M5.BtnB.wasPressed()) {
+            enShowCtrlPanel = !enShowCtrlPanel;
+            M5.Lcd.clear();
+            if (enShowCtrlPanel) drawCtrlPanel();
+        }
+
+        if (enShowCtrlPanel) {
+            handleCtrlPanelTouched();
+        }
+
+        // Telemetry output via Serial (10Hz)
+        uint32_t now_ms = millis();
+        TelemetryData tel;
+        if (now_ms - last_telemetry_ms >= 100) {
+            if (xQueuePeek(g_telemetry_queue, &tel, 0) == pdTRUE) {
+                last_telemetry_ms = now_ms;
+                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n",
+                              tel.pitch_deg, tel.pitch_rate_dps, tel.rpm_cmd,
+                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us);
+            }
+        }
+
+        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(50));
+    }
+}
+
+// --- Setup ---
+
+void setup() {
+    Serial.begin(115200);
+
+    auto cfg = M5.config();
+    cfg.internal_rtc = false;
+    cfg.internal_mic = false;
+    cfg.internal_spk = false;
+    cfg.internal_imu = true;
+    M5.begin(cfg);
+    M5.Lcd.fillScreen(BLACK);
+    M5.Lcd.setTextSize(2);
+    M5.Lcd.setCursor(0, 0);
+
+    // I2C mutex
+    g_i2c_mutex = xSemaphoreCreateMutex();
+    configASSERT(g_i2c_mutex != nullptr);
+
+    // Inter-task queues
+    g_cmd_queue = xQueueCreate(8, sizeof(CtrlCommand));
+    g_telemetry_queue = xQueueCreate(1, sizeof(TelemetryData));
+    configASSERT(g_cmd_queue != nullptr);
+    configASSERT(g_telemetry_queue != nullptr);
+
+    // DYNAMIXEL Settings
+    DXL_SERIAL.begin(1000000, SERIAL_8N1, PIN_RX_SERVO, PIN_TX_SERVO);
+    dxl = Dynamixel2Arduino(DXL_SERIAL);
+    dxl.begin(1000000);
+    dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
+
+    if (!dxl.ping(DXL_ID_L)) { M5.Lcd.println("DXL L ping FAIL"); }
+    if (!dxl.ping(DXL_ID_R)) { M5.Lcd.println("DXL R ping FAIL"); }
+    dxl.torqueOff(DXL_ID_L);
+    dxl.torqueOff(DXL_ID_R);
+    dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
+    dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
+    dxl.torqueOn(DXL_ID_L);
+    dxl.torqueOn(DXL_ID_R);
+
+    // Kalman filter init
+    ImuData imu_init = readImuBurst();
+    kalman.setAngle(imu_init.valid ? imu_init.pitch_deg : DEFAULT_PITCH_TARGET);
+
+    // WDT
+    esp_task_wdt_init(1, true);
+
+    // RTOS Tasks
+    const uint32_t MEMORY_STACK = 8192;
+    xTaskCreatePinnedToCore(controlLoopTask, "Control", MEMORY_STACK, NULL, 20, NULL, 1);
+    xTaskCreatePinnedToCore(uiLoopTask,      "UI",      MEMORY_STACK, NULL, 3,  NULL, 0);
+}
+
+void loop() {
 }

--- a/src/ui_task.cpp
+++ b/src/ui_task.cpp
@@ -1,0 +1,108 @@
+#include <Arduino.h>
+#include <M5Unified.h>
+#include "config.h"
+#include "shared_state.h"
+
+static float ui_kp = DEFAULT_KP;
+static float ui_ki = DEFAULT_KI;
+static float ui_kd = DEFAULT_KD;
+static float ui_target = DEFAULT_PITCH_TARGET;
+static bool enShowCtrlPanel = false;
+
+static void drawButton(const char* label, int x, int y, float value) {
+    M5.Display.drawRect(x, y, 50, 30, WHITE);
+    M5.Display.drawString("-", x + 20, y, 2);
+    M5.Display.drawRect(x + 200, y, 50, 30, WHITE);
+    M5.Display.drawString("+", x + 200 + 20, y, 2);
+    M5.Display.setCursor(x + 70, y + 5);
+    M5.Display.print(label);
+    M5.Display.print(": ");
+    M5.Display.println(value, 1);
+}
+
+static void drawCtrlPanel() {
+    drawButton("Ref", 20, 30, ui_target);
+    drawButton("Kp", 20, 70, ui_kp);
+    drawButton("Ki", 20, 110, ui_ki);
+    drawButton("Kd", 20, 150, ui_kd);
+
+    if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        int batteryPercentage = M5.Power.getBatteryLevel();
+        xSemaphoreGive(g_i2c_mutex);
+        M5.Display.setCursor(20, 190);
+        M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
+    }
+}
+
+static void handleCtrlPanelTouched() {
+    auto pos = M5.Touch.getDetail();
+    if (!pos.wasPressed()) return;
+
+    CtrlCommand cmd;
+    bool send = true;
+
+    if (pos.y >= 30 && pos.y < 60) {
+        if (pos.x >= 15 && pos.x < 120)      ui_target -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_target += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_PITCH_TARGET, ui_target}; drawButton("Ref", 20, 30, ui_target); }
+    }
+    else if (pos.y >= 70 && pos.y < 100) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kp -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kp += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KP, ui_kp}; drawButton("Kp", 20, 70, ui_kp); }
+    }
+    else if (pos.y >= 110 && pos.y < 140) {
+        if (pos.x >= 15 && pos.x < 120)      ui_ki -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_ki += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KI, ui_ki}; drawButton("Ki", 20, 110, ui_ki); }
+    }
+    else if (pos.y >= 150 && pos.y < 180) {
+        if (pos.x >= 15 && pos.x < 120)      ui_kd -= 0.2f;
+        else if (pos.x >= 220 && pos.x < 270) ui_kd += 0.2f;
+        else send = false;
+        if (send) { cmd = {CtrlCommandType::SET_KD, ui_kd}; drawButton("Kd", 20, 150, ui_kd); }
+    }
+    else {
+        send = false;
+    }
+
+    if (send) xQueueSend(g_cmd_queue, &cmd, 0);
+}
+
+void uiLoopTask(void *pvParameters) {
+    TickType_t xLastWakeTime = xTaskGetTickCount();
+    uint32_t last_telemetry_ms = 0;
+
+    while (true) {
+        if (xSemaphoreTake(g_i2c_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            M5.update();
+            xSemaphoreGive(g_i2c_mutex);
+        }
+
+        if (M5.BtnB.wasPressed()) {
+            enShowCtrlPanel = !enShowCtrlPanel;
+            M5.Lcd.clear();
+            if (enShowCtrlPanel) drawCtrlPanel();
+        }
+
+        if (enShowCtrlPanel) {
+            handleCtrlPanelTouched();
+        }
+
+        uint32_t now_ms = millis();
+        TelemetryData tel;
+        if (now_ms - last_telemetry_ms >= 100) {
+            if (xQueuePeek(g_telemetry_queue, &tel, 0) == pdTRUE) {
+                last_telemetry_ms = now_ms;
+                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n",
+                              tel.pitch_deg, tel.pitch_rate_dps, tel.rpm_cmd,
+                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us);
+            }
+        }
+
+        vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(50));
+    }
+}

--- a/src/ui_task.cpp
+++ b/src/ui_task.cpp
@@ -8,6 +8,9 @@ static float ui_ki = DEFAULT_KI;
 static float ui_kd = DEFAULT_KD;
 static float ui_target = DEFAULT_PITCH_TARGET;
 static bool enShowCtrlPanel = false;
+static bool ui_speed_enabled = false;
+static bool tel_speed_prev = false;
+static uint8_t speed_confirm_wait = 0;
 
 static void drawButton(const char* label, int x, int y, float value) {
     M5.Display.drawRect(x, y, 50, 30, WHITE);
@@ -32,6 +35,9 @@ static void drawCtrlPanel() {
         M5.Display.setCursor(20, 190);
         M5.Display.printf("M5Core2 Battery: %d%%", batteryPercentage);
     }
+
+    M5.Display.setCursor(20, 210);
+    M5.Display.printf("Speed: %s  ", ui_speed_enabled ? "ON " : "OFF");
 }
 
 static void handleCtrlPanelTouched() {
@@ -82,24 +88,80 @@ void uiLoopTask(void *pvParameters) {
             xSemaphoreGive(g_i2c_mutex);
         }
 
-        if (M5.BtnB.wasPressed()) {
+        // BtnB short click: toggle control panel (wasClicked avoids firing on long press)
+        if (M5.BtnB.wasClicked()) {
             enShowCtrlPanel = !enShowCtrlPanel;
             M5.Lcd.clear();
             if (enShowCtrlPanel) drawCtrlPanel();
+        }
+
+        // BtnB long press: toggle speed control
+        if (M5.BtnB.wasHold()) {
+            ui_speed_enabled = !ui_speed_enabled;
+            tel_speed_prev = false;
+            CtrlCommand cmd = {CtrlCommandType::SET_SPEED_ENABLED, ui_speed_enabled ? 1.0f : 0.0f};
+            xQueueSend(g_cmd_queue, &cmd, 0);
+            if (enShowCtrlPanel) {
+                M5.Display.setCursor(20, 210);
+                M5.Display.printf("Speed: %s  ", ui_speed_enabled ? "ON " : "OFF");
+            }
         }
 
         if (enShowCtrlPanel) {
             handleCtrlPanelTouched();
         }
 
+        // Sync UI speed flag from controller telemetry
+        {
+            TelemetryData peek;
+            if (xQueuePeek(g_telemetry_queue, &peek, 0) == pdTRUE) {
+                if (peek.speed_enabled) {
+                    tel_speed_prev = true;
+                    speed_confirm_wait = 0;
+                } else if (tel_speed_prev && ui_speed_enabled) {
+                    // Falling edge: controller was ON, now OFF (auto-disable)
+                    ui_speed_enabled = false;
+                    tel_speed_prev = false;
+                    speed_confirm_wait = 0;
+                    if (enShowCtrlPanel) {
+                        M5.Display.setCursor(20, 210);
+                        M5.Display.printf("Speed: OFF ");
+                    }
+                } else if (ui_speed_enabled && !tel_speed_prev) {
+                    // Waiting for controller to confirm enable
+                    speed_confirm_wait++;
+                    if (speed_confirm_wait >= 10) {
+                        ui_speed_enabled = false;
+                        speed_confirm_wait = 0;
+                        if (enShowCtrlPanel) {
+                            M5.Display.setCursor(20, 210);
+                            M5.Display.printf("Speed: OFF ");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Heartbeat: send v_d=0/yaw=0 while speed enabled (deadman keepalive)
+        if (ui_speed_enabled) {
+            CtrlCommand cmd_v = {CtrlCommandType::SET_VELOCITY_CMD, 0.0f};
+            CtrlCommand cmd_y = {CtrlCommandType::SET_YAW_RATE_CMD, 0.0f};
+            xQueueSend(g_cmd_queue, &cmd_v, 0);
+            xQueueSend(g_cmd_queue, &cmd_y, 0);
+        }
+
+        // Telemetry output (100ms interval)
         uint32_t now_ms = millis();
         TelemetryData tel;
         if (now_ms - last_telemetry_ms >= 100) {
             if (xQueuePeek(g_telemetry_queue, &tel, 0) == pdTRUE) {
                 last_telemetry_ms = now_ms;
-                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n",
+                Serial.printf(">pitch:%.2f\n>rate:%.2f\n>rpm:%.1f\n>P:%.2f\n>I:%.3f\n>D:%.2f\n>loop_us:%u\n"
+                              ">v:%.4f\n>theta_off:%.2f\n>v_err:%.4f\n>v_int:%.4f\n>sr_us:%u\n>spd:%d\n",
                               tel.pitch_deg, tel.pitch_rate_dps, tel.rpm_cmd,
-                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us);
+                              tel.P_term, tel.I_term, tel.D_term, tel.loop_us,
+                              tel.v_measured, tel.theta_offset, tel.v_error, tel.v_integral,
+                              tel.sync_read_us, tel.speed_enabled ? 1 : 0);
             }
         }
 


### PR DESCRIPTION
## Summary
- 速度制御外部ループ（25Hz）を追加: Sync Read 車輪速度計測 → 速度 PI（back-calc anti-windup 5条件）→ θ_offset → 内部 PID
- ヨーレート指令による差動ミキシング（track_width=0.0669m, WHEEL_BASE 定数追加）
- Sync Write による非ブロッキングモータ駆動（旧 driveTire/setGoalVelocity を置換）
- 転倒検知時の速度状態完全リセット、デッドマンタイムアウト（500ms）
- UI: BtnB 短押し(wasClicked)/長押し(wasHold) 分離、テレメトリ落ちエッジ同期＋確認タイムアウト
- テレメトリ 14 フィールド拡張（v_measured, theta_offset, v_error, v_integral, sync_read_us, speed_enabled）
- firmware-guide.md / control-loop.drawio.svg / plan-pid-velocity-control.md 追加・更新

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `include/config.h` | 速度制御定数（WHEEL_BASE, PI ゲイン, リミット, Sync R/W アドレス） |
| `include/shared_state.h` | CtrlCommandType 5コマンド追加, TelemetryData 6フィールド追加 |
| `src/control_task.cpp` | Sync Write/Read, 速度 PI, ヨー差動, 転倒検知分離, 予算ガード, デッドマン |
| `src/ui_task.cpp` | wasClicked/wasHold 分離, テレメトリ同期, ハートビート |
| `docs/plan-pid-velocity-control.md` | 設計文書（Codex adversarial 17回 + standard 17回で承認） |
| `docs/firmware-guide.md` | ガイド更新（CtrlCommandType, TelemetryData, driveMotors, 転倒リセット） |
| `docs/control-loop.drawio.svg` | 制御ループ図更新（速度外部ループ + 差動パス追加） |

## Test plan
- [ ] PlatformIO ビルド成功確認 ✅
- [ ] Codex standard review 指摘ゼロ ✅ (9ラウンド)
- [ ] 実機フラッシュ + 倒立確認
- [ ] 速度制御 ON/OFF トグル（BtnB 長押し）
- [ ] 転倒→速度自動停止→復帰確認
- [ ] デッドマンタイムアウト動作確認
- [ ] テレメトリ Serial Plotter 全14フィールド表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)