### PR TITLE
PID制御状態の重複リセットを整理

### DIFF
--- a/src/control_task.cpp
+++ b/src/control_task.cpp
@@ -30,8 +30,8 @@ static DYNAMIXEL::InfoSyncWriteInst_t vel_sync_write = {
 static void driveMotors(int rpm_L, int rpm_R) {
     int32_t raw_L = (int32_t)(-rpm_L / DXL_VEL_UNIT);
     int32_t raw_R = (int32_t)( rpm_R / DXL_VEL_UNIT);
-    memcpy(goal_vel_buf_L, &raw_L, 4);
-    memcpy(goal_vel_buf_R, &raw_R, 4);
+    memcpy(goal_vel_buf_L, &raw_L, sizeof(raw_L));
+    memcpy(goal_vel_buf_R, &raw_R, sizeof(raw_R));
     vel_sync_write.is_info_changed = true;
     dxl.syncWrite(&vel_sync_write);
 }
@@ -84,6 +84,64 @@ static VelReadResult readWheelVelocity() {
     return r;
 }
 
+struct BalancePidState {
+    float integral;
+    float previous_error;
+    float derivative_filtered;
+    bool active;
+};
+
+struct SpeedControlState {
+    bool enabled;
+    bool was_enabled;
+    float kp;
+    float ki;
+    float velocity_cmd;
+    float yaw_rate_cmd;
+    float integral;
+    float theta_offset;
+    float measured_velocity;
+    float velocity_error;
+    float previous_velocity_cmd;
+    uint8_t divider_count;
+    uint8_t sync_read_fail_count;
+    uint32_t last_cmd_ms;
+    uint32_t last_sync_read_us;
+};
+
+static void resetBalancePid(BalancePidState& pid) {
+    pid.integral = 0.0f;
+    pid.previous_error = 0.0f;
+    pid.derivative_filtered = 0.0f;
+    pid.active = false;
+}
+
+static void resetSpeedCommand(SpeedControlState& speed) {
+    speed.velocity_cmd = 0.0f;
+    speed.yaw_rate_cmd = 0.0f;
+    speed.integral = 0.0f;
+    speed.theta_offset = 0.0f;
+    speed.sync_read_fail_count = 0;
+}
+
+static void enableSpeedControl(SpeedControlState& speed) {
+    speed.enabled = true;
+    speed.last_cmd_ms = millis();
+    speed.sync_read_fail_count = 0;
+}
+
+static void disableSpeedControl(SpeedControlState& speed) {
+    speed.enabled = false;
+    resetSpeedCommand(speed);
+}
+
+static void resetSpeedAfterFall(SpeedControlState& speed) {
+    disableSpeedControl(speed);
+    speed.measured_velocity = 0.0f;
+    speed.previous_velocity_cmd = 0.0f;
+    speed.divider_count = 0;
+}
+
 // --- Control Loop ---
 void controlLoopTask(void *pvParameters) {
     esp_task_wdt_add(NULL);
@@ -93,28 +151,16 @@ void controlLoopTask(void *pvParameters) {
     float ki = DEFAULT_KI;
     float kd = DEFAULT_KD;
     float target = DEFAULT_PITCH_TARGET;
-    float I_acc = 0.0f;
-    float preP = 0.0f;
-    float D_filtered = 0.0f;
-    bool pid_active = false;
+    BalancePidState pid = {0.0f, 0.0f, 0.0f, false};
     int64_t prev_us = 0;
 
-    // Speed control state
-    bool speed_enabled = false;
-    bool speed_was_enabled = false;
-    float kp_speed = DEFAULT_KP_SPEED;
-    float ki_speed = DEFAULT_KI_SPEED;
-    float v_d = 0.0f;
-    float yaw_rate_cmd = 0.0f;
-    float v_integral = 0.0f;
-    float theta_offset = 0.0f;
-    float v_measured = 0.0f;
-    float v_error_out = 0.0f;
-    float v_d_prev = 0.0f;
-    uint8_t speed_divider_count = 0;
-    uint8_t sync_read_fail_count = 0;
-    uint32_t last_cmd_ms = 0;
-    uint32_t last_sync_read_us = 0;
+    SpeedControlState speed = {
+        false, false,
+        DEFAULT_KP_SPEED, DEFAULT_KI_SPEED,
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0, 0,
+        0, 0,
+    };
 
     while (true) {
         esp_task_wdt_reset();
@@ -129,35 +175,25 @@ void controlLoopTask(void *pvParameters) {
                 case CtrlCommandType::SET_KD:           kd = cmd.value; break;
                 case CtrlCommandType::SET_PITCH_TARGET: target = cmd.value; break;
                 case CtrlCommandType::SET_SPEED_ENABLED:
-                    speed_enabled = (cmd.value > 0.5f);
-                    if (speed_enabled) {
-                        last_cmd_ms = millis();
-                        sync_read_fail_count = 0;
-                    } else {
-                        v_d = 0; yaw_rate_cmd = 0;
-                        v_integral = 0; theta_offset = 0;
-                        sync_read_fail_count = 0;
-                    }
+                    if (cmd.value > 0.5f) enableSpeedControl(speed);
+                    else disableSpeedControl(speed);
                     break;
-                case CtrlCommandType::SET_KP_SPEED:     kp_speed = cmd.value; break;
-                case CtrlCommandType::SET_KI_SPEED:     ki_speed = cmd.value; break;
+                case CtrlCommandType::SET_KP_SPEED:     speed.kp = cmd.value; break;
+                case CtrlCommandType::SET_KI_SPEED:     speed.ki = cmd.value; break;
                 case CtrlCommandType::SET_VELOCITY_CMD:
-                    v_d = constrain(cmd.value, -V_CMD_MAX, V_CMD_MAX);
-                    last_cmd_ms = millis();
+                    speed.velocity_cmd = constrain(cmd.value, -V_CMD_MAX, V_CMD_MAX);
+                    speed.last_cmd_ms = millis();
                     break;
                 case CtrlCommandType::SET_YAW_RATE_CMD:
-                    yaw_rate_cmd = cmd.value;
-                    last_cmd_ms = millis();
+                    speed.yaw_rate_cmd = cmd.value;
+                    speed.last_cmd_ms = millis();
                     break;
             }
         }
 
         // --- Command freshness timeout ---
-        if (speed_enabled && (millis() - last_cmd_ms > CMD_FRESHNESS_MS)) {
-            speed_enabled = false;
-            v_d = 0; yaw_rate_cmd = 0;
-            v_integral = 0; theta_offset = 0;
-            sync_read_fail_count = 0;
+        if (speed.enabled && (millis() - speed.last_cmd_ms > CMD_FRESHNESS_MS)) {
+            disableSpeedControl(speed);
         }
 
         // --- dt calculation ---
@@ -183,135 +219,122 @@ void controlLoopTask(void *pvParameters) {
         float fall_error = target - pitch_filtered;
         if (fall_error < -FALL_THRESHOLD_DEG || FALL_THRESHOLD_DEG < fall_error) {
             driveMotors(0, 0);
-            I_acc = 0.0f;
-            preP = 0.0f;
-            D_filtered = 0.0f;
-            pid_active = false;
-            speed_enabled = false;
-            v_d = 0.0f;
-            yaw_rate_cmd = 0.0f;
-            theta_offset = 0.0f;
-            v_integral = 0.0f;
-            v_measured = 0.0f;
-            v_d_prev = 0.0f;
-            speed_divider_count = 0;
-            sync_read_fail_count = 0;
+            resetBalancePid(pid);
+            resetSpeedAfterFall(speed);
             TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, 0, 0, 0, 0,
                                  (uint32_t)(esp_timer_get_time() - now_us), true,
-                                 0, 0, 0, 0, 0, speed_enabled};
+                                 0, 0, 0, 0, 0, speed.enabled};
             xQueueOverwrite(g_telemetry_queue, &tel);
             vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);
             continue;
         }
 
         // --- Speed control outer loop (25 Hz) ---
-        speed_divider_count++;
-        if (speed_enabled && speed_divider_count >= SPEED_LOOP_DIVIDER) {
-            speed_divider_count = 0;
+        speed.divider_count++;
+        if (speed.enabled && speed.divider_count >= SPEED_LOOP_DIVIDER) {
+            speed.divider_count = 0;
             float dt_speed = dt * SPEED_LOOP_DIVIDER;
 
             // Budget guard: only run Sync Read if enough time remains
             int64_t budget_us = esp_timer_get_time() - now_us;
             if (budget_us < 600) {
                 VelReadResult vr = readWheelVelocity();
-                last_sync_read_us = vr.elapsed_us;
+                speed.last_sync_read_us = vr.elapsed_us;
                 if (vr.valid) {
-                    v_measured = vr.v;
-                    sync_read_fail_count = 0;
+                    speed.measured_velocity = vr.v;
+                    speed.sync_read_fail_count = 0;
                 } else {
-                    sync_read_fail_count++;
+                    speed.sync_read_fail_count++;
                 }
             }
-            if (sync_read_fail_count >= SYNC_READ_FAIL_LIMIT) {
-                speed_enabled = false;
-                v_d = 0; yaw_rate_cmd = 0;
-                v_integral = 0; theta_offset = 0;
-                sync_read_fail_count = 0;
+            if (speed.sync_read_fail_count >= SYNC_READ_FAIL_LIMIT) {
+                disableSpeedControl(speed);
             }
 
             // Speed PI with 5-condition anti-windup
-            float v_error = v_d - v_measured;
-            v_error_out = v_error;
+            float v_error = speed.velocity_cmd - speed.measured_velocity;
+            speed.velocity_error = v_error;
 
-            // Condition 1: v_d sign change → reset
-            if ((v_d > 0 && v_d_prev < 0) || (v_d < 0 && v_d_prev > 0)) {
-                v_integral = 0.0f;
+            // Condition 1: velocity command sign change -> reset
+            if ((speed.velocity_cmd > 0 && speed.previous_velocity_cmd < 0)
+                || (speed.velocity_cmd < 0 && speed.previous_velocity_cmd > 0)) {
+                speed.integral = 0.0f;
             }
-            // Condition 2: v_d nonzero→zero transition → reset
-            if (fabsf(v_d) < 1e-4f && fabsf(v_d_prev) >= 1e-4f) {
-                v_integral = 0.0f;
+            // Condition 2: velocity command nonzero-to-zero transition -> reset
+            if (fabsf(speed.velocity_cmd) < 1e-4f && fabsf(speed.previous_velocity_cmd) >= 1e-4f) {
+                speed.integral = 0.0f;
             }
 
             // Condition 3: normal integration
-            v_integral += v_error * dt_speed;
-            v_integral = constrain(v_integral, -V_INTEGRAL_LIMIT, V_INTEGRAL_LIMIT);
+            speed.integral += v_error * dt_speed;
+            speed.integral = constrain(speed.integral, -V_INTEGRAL_LIMIT, V_INTEGRAL_LIMIT);
 
             // Condition 4: output + back-calculation anti-windup
-            float theta_raw = kp_speed * v_error + ki_speed * v_integral;
-            theta_offset = constrain(theta_raw, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
-            if (theta_raw != theta_offset && fabsf(ki_speed) > 1e-6f) {
-                v_integral = (theta_offset - kp_speed * v_error) / ki_speed;
+            float theta_raw = speed.kp * v_error + speed.ki * speed.integral;
+            speed.theta_offset = constrain(theta_raw, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
+            if (theta_raw != speed.theta_offset && fabsf(speed.ki) > 1e-6f) {
+                speed.integral = (speed.theta_offset - speed.kp * v_error) / speed.ki;
             }
 
             // Condition 5: direction consistency (with deadband)
-            if (v_error * theta_offset < -1e-6f && fabsf(v_error) > V_ERR_DEADBAND) {
-                v_integral = 0.0f;
-                theta_offset = constrain(kp_speed * v_error, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
+            if (v_error * speed.theta_offset < -1e-6f && fabsf(v_error) > V_ERR_DEADBAND) {
+                speed.integral = 0.0f;
+                speed.theta_offset = constrain(speed.kp * v_error, -THETA_OFFSET_MAX, THETA_OFFSET_MAX);
             }
 
-            v_d_prev = v_d;
+            speed.previous_velocity_cmd = speed.velocity_cmd;
         }
 
-        if (!speed_enabled) {
-            theta_offset = 0.0f;
-            v_integral = 0.0f;
+        if (!speed.enabled) {
+            speed.theta_offset = 0.0f;
+            speed.integral = 0.0f;
         }
 
         // --- Inner PID/PD loop ---
-        float effective_target = target - theta_offset;
+        float effective_target = target - speed.theta_offset;
         float pitch_error = effective_target - pitch_filtered;
 
         float P_val = pitch_error;
 
-        // Reset derivative state on speed→non-speed transition BEFORE D computation
-        if (!speed_enabled && speed_was_enabled) {
-            preP = P_val;
-            D_filtered = 0.0f;
+        // Reset derivative state on speed-to-normal transition BEFORE D computation
+        if (!speed.enabled && speed.was_enabled) {
+            pid.previous_error = P_val;
+            pid.derivative_filtered = 0.0f;
         }
 
         float D_raw;
-        if (!pid_active) {
+        if (!pid.active) {
             D_raw = 0.0f;
-            pid_active = true;
+            pid.active = true;
         } else {
-            if (speed_enabled) {
+            if (speed.enabled) {
                 // Derivative-on-measurement to avoid theta_offset step kicks
                 D_raw = -imu.pitch_rate_dps;
             } else {
                 // Derivative-on-error (existing behavior)
-                D_raw = (P_val - preP) / dt;
+                D_raw = (P_val - pid.previous_error) / dt;
             }
         }
-        D_filtered = 0.2f * D_raw + 0.8f * D_filtered;
-        float D_val = D_filtered;
-        preP = P_val;
+        pid.derivative_filtered = 0.2f * D_raw + 0.8f * pid.derivative_filtered;
+        float D_val = pid.derivative_filtered;
+        pid.previous_error = P_val;
 
         float rpm_f;
-        if (speed_enabled) {
-            I_acc = 0.0f;
+        if (speed.enabled) {
+            pid.integral = 0.0f;
             rpm_f = kp * P_val + kd * D_val;
         } else {
-            I_acc += P_val * dt;
+            pid.integral += P_val * dt;
             float i_limit = 50.0f / (fabsf(ki) + 1e-6f);
-            I_acc = constrain(I_acc, -i_limit, i_limit);
-            rpm_f = kp * P_val + ki * I_acc + kd * D_val;
+            pid.integral = constrain(pid.integral, -i_limit, i_limit);
+            rpm_f = kp * P_val + ki * pid.integral + kd * D_val;
         }
-        speed_was_enabled = speed_enabled;
+        speed.was_enabled = speed.enabled;
 
         // Yaw differential mixing: turn_ff = 0.5 * yaw_rate * track_width / wheel_r
         float yaw_rpm = 0.0f;
-        if (speed_enabled && fabsf(yaw_rate_cmd) > 1e-4f) {
-            float yaw_omega = yaw_rate_cmd * WHEEL_BASE / (2.0f * WHEEL_R);
+        if (speed.enabled && fabsf(speed.yaw_rate_cmd) > 1e-4f) {
+            float yaw_omega = speed.yaw_rate_cmd * WHEEL_BASE / (2.0f * WHEEL_R);
             yaw_rpm = yaw_omega * (60.0f / (2.0f * M_PI));
         }
         int rpm_L = constrain((int)(rpm_f - yaw_rpm), -RPM_LIMIT, RPM_LIMIT);
@@ -320,9 +343,9 @@ void controlLoopTask(void *pvParameters) {
 
         uint32_t elapsed = (uint32_t)(esp_timer_get_time() - now_us);
         TelemetryData tel = {pitch_filtered, imu.pitch_rate_dps, (float)((rpm_L + rpm_R) / 2),
-                             P_val, I_acc, D_val, elapsed, false,
-                             v_measured, theta_offset, v_error_out, v_integral,
-                             last_sync_read_us, speed_enabled};
+                             P_val, pid.integral, D_val, elapsed, false,
+                             speed.measured_velocity, speed.theta_offset, speed.velocity_error,
+                             speed.integral, speed.last_sync_read_us, speed.enabled};
         xQueueOverwrite(g_telemetry_queue, &tel);
 
         vTaskDelayUntil(&xLastWakeTime, CTRL_PERIOD_TICKS);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,12 @@ QueueHandle_t g_cmd_queue = nullptr;
 QueueHandle_t g_telemetry_queue = nullptr;
 SemaphoreHandle_t g_i2c_mutex = nullptr;
 
+static constexpr uint8_t DXL_IDS[] = {DXL_ID_L, DXL_ID_R};
+static const char* DXL_PING_FAIL_MESSAGES[] = {
+    "DXL L ping FAIL",
+    "DXL R ping FAIL",
+};
+
 // Task entry points (defined in control_task.cpp / ui_task.cpp)
 extern void controlLoopTask(void *pvParameters);
 extern void uiLoopTask(void *pvParameters);
@@ -47,14 +53,14 @@ void setup() {
     dxl = Dynamixel2Arduino(dxl_serial);
     dxl.begin(DXL_BAUDRATE);
     dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
-    if (!dxl.ping(DXL_ID_L)) { M5.Lcd.println("DXL L ping FAIL"); }
-    if (!dxl.ping(DXL_ID_R)) { M5.Lcd.println("DXL R ping FAIL"); }
-    dxl.torqueOff(DXL_ID_L);
-    dxl.torqueOff(DXL_ID_R);
-    dxl.setOperatingMode(DXL_ID_L, OP_VELOCITY);
-    dxl.setOperatingMode(DXL_ID_R, OP_VELOCITY);
-    dxl.torqueOn(DXL_ID_L);
-    dxl.torqueOn(DXL_ID_R);
+    for (uint8_t i = 0; i < 2; ++i) {
+        if (!dxl.ping(DXL_IDS[i])) {
+            M5.Lcd.println(DXL_PING_FAIL_MESSAGES[i]);
+        }
+    }
+    for (uint8_t id : DXL_IDS) dxl.torqueOff(id);
+    for (uint8_t id : DXL_IDS) dxl.setOperatingMode(id, OP_VELOCITY);
+    for (uint8_t id : DXL_IDS) dxl.torqueOn(id);
 
     // IMU
     imuDriver.begin(g_i2c_mutex);


### PR DESCRIPTION
## 概要
- 倒立 PID と速度制御の状態を構造体に集約
- 転倒時・速度制御無効化時のリセット処理を helper 化
- DYNAMIXEL 左右初期化の重複をループ化

## 検証
- git diff --check
- ~/.platformio/penv/bin/pio run -e m5stack-core2

## 注意
- 物理行数は 149 insertions / 120 deletions で差し引き +29 行
- Goal Velocity ベースの既存動作は維持し、電流制御化そのものは次段階で扱う
- 未追跡 docs は本 PR に含めない