### PR TITLE
安全機構の判断ロジック純関数抽出 + dt p95計算コア（監査残課題 段階1〜3）

### DIFF
--- a/docs/plans/2026-07-06-safety-core-extraction.md
+++ b/docs/plans/2026-07-06-safety-core-extraction.md
@@ -1,0 +1,284 @@
+# 安全機構の純関数抽出 + dt p95 計算コア（監査残課題 段階1〜3）
+
+作成日: 2026-07-06
+ブランチ: `feat/safety-core-extraction`（`dev/current-mode-xl330-fable5` から独立分岐。PR は同ブランチへ）
+出典: `docs/reviews/2026-07-04-best-practice-audit.md`（監査 HIGH「安全機構の mock テスト未実装」・MEDIUM「dt p95 soak gate 未実装」）
+ユーザ承認: 2026-07-06 に段階1〜3 の実装を承認済み（段階4〜5 = control_task 周期本体の関数抽出・p95 ゲート結線・transport 抽象化は本 PR の非スコープ）。
+
+## 1. 目的・スコープ
+
+設計書（`docs/plans/2026-07-02-current-mode-freertos-redesign.md` §4.2/§4.3/§6）が安全論拠の
+根幹として要求しながら host テスト空白になっている判断ロジックを、**ロジック変更ゼロの
+純関数抽出**で `src/core/`（Arduino 非依存・native テスト可能層）へ移し、監査 5 テストの
+うち 2 本（配達証明の誤受理・Watchdog 遷移表の左右非対称）の**判断ロジック部分**を
+テスト可能化する（I/O 実行列を含む完全クローズは段階5 の transport fake が担う —
+下表・§8 参照）。あわせて dt p95 soak gate（設計書 §6）の**計算コア**を新設する
+（FSM への結線は段階4）。
+
+| 段階 | 内容 | 対応する監査テスト |
+|---|---|---|
+| 1a | 配達証明の検証述語を `src/core/dxl_verify.h` へ抽出 | テスト1「配達証明の誤受理」の**述語部分の特性化**（完全クローズは段階5、§8参照） |
+| 1b | Bus Watchdog 遷移表の判定 + 復旧頻度制限を `src/core/watchdog_policy.h` へ抽出 | テスト4「遷移表の左右非対称」（判定・順序契約。I/O 実行列の検証は段階5） |
+| 2 | `PlausibilityMonitor` を `src/core/plausibility_monitor.h` へ移設（逐語移動） | 既存妥当性監視の恒久テスト化 |
+| 3 | dt p95 計算コア `src/core/dt_stats.h` を新設 | dt p95 soak gate の土台（結線は段階4） |
+
+**非スコープ（明示）**: hw 層 I/O の transport 抽象化（段階5）、`checkWatchdog` の I/O
+実行部・`watchdogRecoverOne` の I/O 列の検証、未検証トルク窓/検疫沈黙/保存レースの
+統合テスト（段階4〜5）、INITIALIZING への p95 ゲート結線・`FaultReason` 追加・予算閾値
+定数（段階4）、制御則・安全機構の**挙動変更一切**。
+
+## 2. 設計原則
+
+1. **ロジック変更ゼロ**: 抽出は「判断式の移動 + 呼び出し置換」のみ。判定条件・比較
+   演算子・境界値・状態更新順序を一切変えない（§3 に現行コードとの対応を明記）。
+2. **リリース挙動同一**: バイナリの byte 同一は主張しない（inline 境界・シンボルが
+   動くため）。保証するのは挙動同一性 = 抽出前後で全既存テストパス + 判定式の
+   逐語対応（レビューで対査）。
+3. **既存パターン踏襲**: `src/core/` の既存ヘッダ（`pid.h`/`safety_fsm.h` 等）と同じ
+   header-only・`namespace core`・cfg 定数参照スタイル。
+4. **テストは境界値と非対称ケースを網羅**: 特に Watchdog は左右の全非対称組合せを
+   遷移表としてテストする（§5）。
+
+## 3. 抽出内容（現行コードとの対応）
+
+### 3.1 段階1a: `src/core/dxl_verify.h`（新規）
+
+現行 `DxlWithRxInfo::writeVerified`（`src/hw/dxl_backend.cpp:40-59`）/
+`readVerified`（同 :61-79`）の**受理判定部分**を抽出する。I/O（txInstPacket/
+rxStatusPacket）と param 組み立ては hw 層に残す。
+
+```cpp
+namespace core {
+// Status 応答の観測値ビュー (ゲート1第1回指摘3対応 — rx==nullptr 時に呼び出し側で
+// フィールドを deref させない。ライブラリ型 InfoToParseDXLPacket_t は Arduino 依存の
+// ため core には持ち込まず、POD ビューに写して渡す):
+struct DxlStatusView {
+  bool ok = false;          // rxStatusPacket() が nullptr でない
+  uint8_t id = 0;
+  uint8_t err_idx = 0;
+  uint16_t recv_param_len = 0;
+};
+// WRITE の Status 受理判定 (設計書 §4.2)。現行 dxl_backend.cpp:52-57 と逐語対応:
+//   !st.ok → 拒否 / id 不一致 → 拒否 / err_idx != 0 → 拒否 (ALERT 0x80 含む)
+//   / recv_param_len != 0 → 拒否 (前回 READ の遅延応答を配達証明として誤受理しない)
+inline bool isWriteStatusVerified(const DxlStatusView& st, uint8_t expect_id);
+// READ の Status 受理判定。現行 dxl_backend.cpp:71-76 と逐語対応:
+//   !st.ok / id 不一致 / recv_param_len != expect_len → 拒否
+//   / (err_idx & 0x7F) != 0 → 拒否 (READ は ALERT ビットのみ許容 — HW エラー通知は
+//   ヘルス側で扱う。Result Fail 等は拒否)
+inline bool isReadStatusVerified(const DxlStatusView& st, uint8_t expect_id,
+                                 uint16_t expect_len);
+}
+```
+
+`dxl_backend.cpp` 側は rx 受信後の if 連鎖を「view 構築 + 述語 1 呼び出し」に置換する。
+**view 構築の必須パターン**（nullptr 安全性の call-site 契約。ゲート1第1回指摘3対応 —
+引数評価は関数呼び出し前に行われるため、`rx->id` を引数式に書く形は禁止）:
+
+```cpp
+const auto* rx = rxStatusPacket(...);
+core::DxlStatusView st;
+if (rx != nullptr) { st.ok = true; st.id = rx->id; st.err_idx = rx->err_idx;
+                     st.recv_param_len = rx->recv_param_len; }
+if (!core::isWriteStatusVerified(st, id)) return false;
+```
+
+この call-site パターン（nullptr 時にフィールドへ一切触れない）はゲート2レビューでの
+対査項目とし、計画書のこの節を対査基準にする。データコピーは READ 成功時のみ実行
+（現行と同順序）。
+
+### 3.2 段階1b: `src/core/watchdog_policy.h`（新規）
+
+現行 `DxlBackend::checkWatchdog`（`src/hw/dxl_backend.cpp:371-403`）は I/O と判断が
+混在。判断のみを 2 部品として抽出する:
+
+**API 形状は逐次リデューサ**（ゲート1第1回指摘2対応 — 現行 `checkWatchdog` は
+「rawL 読取失敗で**即** return（rawR を読まない）」「teL 読取失敗で**即** return
+（teR を読まない）」という早期 return を持ち、『両輪分を読んでから一括判定』の
+API では I/O 回数・順序の同一性が破れる。劣化経路でのバス往復・タイムアウト遅延の
+増加は安全上許容しない）:
+
+```cpp
+namespace core {
+enum class WatchdogVerdict : uint8_t { Pending, Ok, Fault, ProceedRecover };
+// 現行 checkWatchdog の判断列を I/O と同じ逐次順で消費するリデューサ。
+// call-site 契約: 読取 I/O は現行と同一順 (raw[L]→raw[R]→(トリップ時のみ)
+// te[L]→te[R]) で行い、各 feed が Pending 以外を返した時点で以降の I/O を
+// 行わない (早期 return の I/O 回数同一性)。逐語対応は現行 :374-388:
+//   feedRaw: 読取失敗 → torque_may_be_on ? Fault : Ok (即時) /
+//            両輪 feed 完了かつ非トリップ (いずれも != tripped_value) → Ok /
+//            トリップあり → Pending (TE 読取へ)
+//   feedTe:  読取失敗 → Fault (即時) / 両輪 feed 完了かつ両輪 0 → ProceedRecover /
+//            いずれか非零 → Fault (注: 現行 :388 は両輪読取後に te[0]!=0||te[1]!=0 を
+//            判定するため、teL 非零でも teR の読取は行われる。この I/O 回数も保存
+//            する — 非零検出は両輪 feed 完了時に行う)
+class WatchdogDecision {
+ public:
+  explicit WatchdogDecision(bool torque_may_be_on, uint8_t tripped_value);
+  WatchdogVerdict feedRaw(bool read_ok, uint8_t value);  // L→R の順で最大 2 回
+  WatchdogVerdict feedTe(bool read_ok, uint8_t value);   // L→R の順で最大 2 回
+};
+// 復旧頻度制限 (60s 内 3 回で FAULT)。現行 :390-397 の recover_count_/
+// recover_window_start_s_ 状態機械を逐語移動 (リセット条件 count==0 ||
+// (now - start) > window、++count >= max で deny):
+class WatchdogRecoverLimiter {
+ public:
+  // 復旧を許可するなら true。deny (= FAULT) 時も現行同様 count は増加済みのまま。
+  bool allow(float now_s, float window_s, int max_count);
+ private:
+  int recover_count_ = 0;
+  float recover_window_start_s_ = 0.0f;
+};
+}
+```
+
+`checkWatchdog` 側は「raw 読取ループ内で feedRaw、Pending 以外なら即 return 変換 →
+トリップ時のみ TE 読取ループ内で feedTe → ProceedRecover なら `limiter_.allow(...)` →
+許可時のみ `watchdogRecoverOne` ×2」に再構成（I/O の位置・回数・順序は現行と同一。
+`WatchdogCheck` への写像: Ok→Ok / Fault→Fault / ProceedRecover+allow 拒否→Fault /
+復旧実行失敗→Fault / 成功→Recovered — 現行 :397-402 と同一）。
+`DxlBackend` の生メンバ `recover_count_`/`recover_window_start_s_` は
+`core::WatchdogRecoverLimiter limiter_` に置き換える（状態の意味・遷移は同一）。
+**限界の明示**: リデューサの step 意味論（どの feed で確定するか）は native テストで
+固定するが、**hw 層 call-site が契約どおり feed するかの機械的検証は段階5
+（transport fake）まで残る**（それまでは本節をゲート2対査基準とするレビュー担保）。
+**現行挙動の潜在エッジ（ゲート1第2回指摘で発見・本 PR では挙動保存）**: 現行
+:374-378 は「トリップ済み raw 値を観測した後に他輪の raw 読取が失敗」しても、
+torque_may_be_on==false なら Ok を返す（既知のトリップ証拠が破棄され、復旧も
+FAULT も発生しない）。リデューサはこの挙動を**そのまま保存**する（feedRaw の
+読取失敗判定は先行 raw 値に依存しない）。これはロジック変更ゼロ原則（§2-1）に
+よる意図的判断であり、§5-3 の特性化テストで現行挙動を固定し、§8 に残余リスク
+として記録の上、**挙動修正（トリップ証拠観測後の読取失敗を fail-closed 化）は
+別課題としてユーザへエスカレーション**する（安全挙動の変更は本 PR のスコープ外）。
+
+### 3.3 段階2: `src/core/plausibility_monitor.h`（新規・逐語移動）
+
+現行 `control_task.cpp:18-33` の `PlausibilityMonitor` は既に完全に純粋
+（I/O なし・内部状態は `dwell_` のみ）。置き場所だけが native テストの障害のため、
+クラス本体を**逐語移動**（`namespace core`、cfg 定数参照は現行のまま）。
+`control_task.cpp` はローカル定義を削除し `core::PlausibilityMonitor` を使用。
+
+### 3.4 段階3: `src/core/dt_stats.h`（新規）
+
+設計書 §6「トルク OFF で全経路を ~2s 回して dt p95 が予算内であること」の計算コア。
+
+```cpp
+namespace core {
+// 固定容量 (kCapacity=512 > 200Hz×2s=400) の dt サンプル窓と p95 抽出。
+// heap 不使用 (float 512 本 = 2048B は使用側が静的に確保する想定。結線は段階4)。
+// API は fail-closed (ゲート1第1回指摘4対応 — 空窓/不足窓/溢れ窓が「予算内」に
+// 見える構成を型レベルで作らせない):
+class DtP95Window {
+ public:
+  static constexpr size_t kCapacity = 512;
+  void add(float dt_s);           // 容量超過時は記録せず overflowed_ を立てる
+  size_t size() const;
+  bool overflowed() const;
+  // 窓がゲート判定に使える状態か (サンプル数下限を満たし、溢れていない)。
+  // 段階4 のゲートは ready() && p95(&v) && v <= budget の形でのみ合格し得る。
+  bool ready(size_t min_samples) const;   // = !overflowed_ && size_ >= min_samples
+  // nearest-rank 法: idx = ceil(0.95*n) - 1。n==0 は false を返し *out 不変
+  // (空窓を数値として扱わせない)。作業配列を内部コピーして選択、入力順は非破壊。
+  bool p95(float* out) const;
+  void reset();
+};
+}
+```
+
+p95 定義（nearest-rank、`idx = ceil(0.95*n) - 1`）を採用する理由: 標本補間なしで
+「n サンプル中 95% がこの値以下」を厳密に主張でき、しきい値ゲート（段階4）の
+判定文として明確。選択は `std::nth_element`（`<algorithm>`、heap 不使用）を用いる。
+代替案（既存 8bin ヒストグラム流用）は分解能が bin 境界に量子化されるため不採用
+（起動時 1 回・2KB 一時領域のコストは無視できる。監査調査レポートの比較表参照）。
+既存 `dt_histogram.h`（telemetry 用 monotonic カウンタ）とは目的が異なるため
+統合しない（コメントで相互参照）。
+
+## 4. 変更ファイル一覧
+
+| ファイル | 変更 | リリース挙動 |
+|---|---|---|
+| `src/core/dxl_verify.h` | 新規（DxlStatusView + 述語 2 関数） | 同一（式の移動のみ。call-site の nullptr ガードパターンは §3.1 が対査基準） |
+| `src/core/watchdog_policy.h` | 新規（WatchdogDecision リデューサ + 頻度制限クラス） | 同一（I/O 位置・回数・順序を保存。§3.2 が対査基準） |
+| `src/core/plausibility_monitor.h` | 新規（逐語移動） | 同一 |
+| `src/core/dt_stats.h` | 新規（p95 計算コア） | 影響なし（本 PR では未結線・未使用。ヘッダ追加のみ） |
+| `src/hw/dxl_backend.cpp` | 述語/判定/制限の呼び出し置換 | 同一 |
+| `src/hw/dxl_backend.h` | `recover_count_`/`recover_window_start_s_` → `core::WatchdogRecoverLimiter limiter_` | 同一 |
+| `src/tasks/control_task.cpp` | ローカル `PlausibilityMonitor` 削除 → `core::` 版使用 | 同一 |
+| `test/test_core/test_main.cpp` | 新規テスト群（§5） | — |
+
+## 5. テスト計画（native、追加分）
+
+1. **配達証明 WRITE**（`isWriteStatusVerified`）: 受理 1 + 拒否 4 軸（st.ok=false
+   （= rx nullptr の view、他フィールドは既定値のまま）/ ID 不一致 /
+   err_idx=0x80(ALERT) / err_idx=0x01 / recv_param_len≠0 = 遅延 READ 応答の
+   誤受理拒否）。**述語の限界の文書化テスト**: 同一 ID・err=0・param_len=0 の
+   遅延 WRITE 応答は述語単体では判別不能で受理される（現行実装と同一の挙動）
+   ことを明示的に assert し、テストコメントで §8 の残余リスク（段階5 で
+   transport タイムラインテストによりクローズ）へ参照を張る。
+2. **配達証明 READ**（`isReadStatusVerified`）: 受理（err=0）+ **ALERT のみ (0x80) は
+   受理**（現行仕様: READ の ALERT はデータ有効）+ 拒否 4 軸（rx 失敗 / ID 不一致 /
+   len 不一致 / Result Fail (err & 0x7F ≠ 0、0x81 も拒否)）。
+3. **Watchdog 遷移表**（`WatchdogDecision` リデューサ）: 左右非対称の全ケースを
+   **確定タイミング（どの feed で Pending 以外になるか）込み**で検証 —
+   rawL 読取失敗 → 1 回目の feedRaw で即確定（torque_may_be_on {true→Fault,
+   false→Ok}。rawR を feed しない = I/O 打切り位置の固定）、rawR 読取失敗 →
+   2 回目で即確定、両輪非トリップ → 2 回目の feedRaw で Ok、トリップ {L のみ,
+   R のみ, 両輪} → 2 回目の feedRaw で Pending（TE 段階へ）、teL 読取失敗 →
+   1 回目の feedTe で即 Fault（teR を feed しない）、teR 読取失敗 → 2 回目で
+   Fault、**TE 値の全組合せを確定タイミング込みで固定**（ゲート1第3回指摘対応 —
+   現行 `te[0] != 0 || te[1] != 0` の OR 意味論が `&&` へ写し間違えられても検出
+   できるように）: (teL,teR) = **(1,0) → Fault**・**(0,1) → Fault**・(1,1) → Fault・
+   (0,0) → ProceedRecover、いずれも **2 回目の feedTe 完了時**に確定（1 回目の
+   feedTe は teL=1 でも Pending を返す = teL 非零でも teR 読取まで行う現行 I/O
+   順序契約を同じテストで固定）。**現行挙動の特性化（§3.2 潜在エッジ）**: rawL=0xFF（トリップ）→
+   rawR 読取失敗 の系列が torque_may_be_on=false で Ok / true で Fault となる
+   （先行トリップ証拠が結果に影響しない）ことを明示 assert し、テストコメントで
+   §8 の残余リスク・エスカレーション方針へ参照を張る。
+4. **復旧頻度制限**（`WatchdogRecoverLimiter`）: 窓内 2 回目まで allow / 3 回目 deny /
+   窓経過（> 比較の境界: ちょうど window_s は同一窓、window_s+ε で新窓）で
+   リセット / deny 後も窓内は deny 継続。
+5. **PlausibilityMonitor**: fb_valid=false で不判定・dwell 非蓄積 / torque_on 乖離の
+   dwell 蓄積→ 閾値超で true（> 比較の境界確認）/ 正常戻りで dwell リセット /
+   torque_off 残留電流経路 / reset()。
+6. **DtP95Window**: n=1 / n=20 の既知分布（nearest-rank の期待 idx を手計算で固定）/
+   未ソート入力 / 重複値 / n=400（2s 相当）/ 容量 512 超過で overflowed かつ既存
+   サンプル保持 / reset / p95() が入力順を破壊しない（呼出し前後で add 継続可能）/
+   **fail-closed 検証**: n=0 で p95() が false（*out 不変）/ ready(400) が
+   n=399 で false・n=400 で true / overflowed 時 ready が常に false /
+   「ready && p95 && v<=budget」合成ゲートが空窓・不足窓・溢れ窓で合格し得ない
+   ことのテーブルテスト。
+
+既存テスト全パス（回帰なし）。抽出前後の等価性は「既存の関連テスト（FSM・
+watchdog 関連の統合的な期待値があれば）が無修正でパスすること」+ 判定式の逐語
+レビューで担保する。
+
+## 6. 検証（PR 前に必須）
+
+1. `pio test -e native` 全パス（既存 32 本 + 新規。pio は `~/.platformio/penv/bin/pio`）
+2. `pio run -e m5stack-core2` 成功（リリース経路のコンパイル確認）
+
+（注: `scripts/verify_builds.sh`・trace env・wifi_secrets 分岐は PR #27/#28 系列にのみ
+存在し、dev 起点の本ブランチには無いことを 2026-07-06 に確認済み。本ブランチの
+検証は上記 2 点で完結する。#27 と合流後は verify_builds.sh が両系列の変更を包含して
+検証する。）
+
+## 7. Git 運用
+
+- コミットは日本語・1 目的 1 コミット・`Co-Authored-By` トレーラ。
+- PR base = `dev/current-mode-xl330-fable5`（マージはユーザ判断）。
+- **PR #27 との合流時の競合見込み**: `control_task.cpp` を両系列が編集するが、領域が
+  異なる（本 PR は :18-33 のクラス削除、#27 は LoopState/publish 部の追加）ため
+  自明に解消可能な見込み。PR 本文に注記する。
+- `docs/reviews/`・`prompt_memo.md`・`claude_best_fable.sh`・handover 文書は
+  コミットしない。
+
+## 8. リスクと限界
+
+| リスク | 対応 |
+|---|---|
+| 抽出時の判定式の写し間違い（等価性の破れ） | §3 の逐語対応表 + 境界値テスト（§5）+ ゲート2 レビューで対査。比較演算子（`>` vs `>=`）と評価順序をテストで固定 |
+| `WatchdogRecoverLimiter` の状態移動でタイミング意味が変わる | 現行のリセット条件・インクリメント位置・deny 後の状態を逐語移動し、§5-4 で deny 継続まで検証 |
+| dt_stats.h が未使用ヘッダとしてリリースに影響 | どの TU からも include されない（テストのみが include）。段階4 で結線するまで dead file であることを PR 本文に明記 |
+| 段階1〜3 では監査テスト 2/5 本のみ（残 3 本は未カバー） | 意図的な段階分割（ユーザ承認済み）。残りは段階4〜5 の別 PR |
+| **トリップ観測後の他輪 raw 読取失敗が torque-off 経路で Ok になる**（現行 :374-378 の早期 return 意味論。既知トリップ証拠の破棄） | 現行実装と同一の残余リスク（本 PR は挙動を変えない）。§5-3 の特性化テストで固定し、fail-closed 化（例: トリップ証拠観測後の読取失敗 → Fault）は**別課題としてユーザへエスカレーション**（安全挙動変更のためユーザ判断 + 独立レビューが必要） |
+| **同一 ID・err=0・param_len=0 の遅延 WRITE Status は述語では判別不能**（drainRx は tx 前の残留バイトのみ除去し、tx 後に到着する遅延応答は防げない） | 現行実装と同一の残余リスク（本 PR は挙動を変えない）。§5-1 で述語の限界を明示テスト化し、段階5 の transport タイムラインテスト（同一 ID 遅延 OK 応答の注入）でクローズする。監査テスト1の「完全クローズ」は段階5 完了まで主張しない（§1 表の注記） |

--- a/src/core/dt_stats.h
+++ b/src/core/dt_stats.h
@@ -1,0 +1,71 @@
+// dt_stats.h — dt p95 計算コア (設計書 §6「トルク OFF で全経路を ~2s 回して
+// dt p95 が予算内であること」の土台)。Arduino 非依存・heap 不使用。段階3
+// 新設 (FSM への結線 = ゲート判定への使用は段階4。本 PR では未結線・未使用。
+// docs/plans/2026-07-06-safety-core-extraction.md §3.4)。
+//
+// 既存 dt_histogram.h (telemetry 用 monotonic カウンタ。運用中の粗い bin
+// 分布を低コストで可視化する目的) とは目的が異なるため統合しない: 本ヘッダ
+// は起動時 soak gate 向けに、量子化なしの厳密な nearest-rank p95 を 1 回
+// 抽出する用途。
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+namespace core {
+
+// 固定容量 (kCapacity=512 > 200Hz×2s=400) の dt サンプル窓と p95 抽出。
+// heap 不使用 (float 512 本 = 2048B は使用側が静的に確保する想定。結線は
+// 段階4)。API は fail-closed (ゲート1第1回指摘4対応 — 空窓/不足窓/溢れ窓が
+// 「予算内」に見える構成を型レベルで作らせない): 段階4 のゲートは
+// ready() && p95(&v) && v <= budget の形でのみ合格し得る。
+class DtP95Window {
+ public:
+  static constexpr size_t kCapacity = 512;
+
+  // 容量超過時は記録せず overflowed_ を立てる (既存サンプルは保持したまま)。
+  void add(float dt_s) {
+    if (size_ < kCapacity) {
+      buf_[size_++] = dt_s;
+    } else {
+      overflowed_ = true;
+    }
+  }
+
+  size_t size() const { return size_; }
+  bool overflowed() const { return overflowed_; }
+
+  // 窓がゲート判定に使える状態か (サンプル数下限を満たし、溢れていない)。
+  bool ready(size_t min_samples) const {
+    return !overflowed_ && size_ >= min_samples;
+  }
+
+  // nearest-rank 法: idx = ceil(0.95*n) - 1。n==0 は false を返し *out 不変
+  // (空窓を数値として扱わせない)。作業配列を内部コピーして選択、入力順は
+  // 非破壊 (add() を呼出し前後で継続可能)。
+  // idx の算出は 0.95 = 19/20 の厳密な整数演算 (19*n+19)/20 - 1 で行い、
+  // ceil(0.95*n) を浮動小数点で計算した場合の丸め誤差 (n が大きいほど
+  // 境界値で ceil の結果が 1 ずれ得る) を避ける。数学的には
+  // ceil(19*n/20) == floor((19*n + 19)/20) (正整数の天井除算の標準変形)。
+  bool p95(float* out) const {
+    if (size_ == 0) return false;
+    const size_t idx = (19 * size_ + 19) / 20 - 1;
+    float work[kCapacity];
+    std::copy(buf_, buf_ + size_, work);
+    std::nth_element(work, work + idx, work + size_);
+    *out = work[idx];
+    return true;
+  }
+
+  void reset() {
+    size_ = 0;
+    overflowed_ = false;
+  }
+
+ private:
+  float buf_[kCapacity];
+  size_t size_ = 0;
+  bool overflowed_ = false;
+};
+
+}  // namespace core

--- a/src/core/dxl_verify.h
+++ b/src/core/dxl_verify.h
@@ -1,0 +1,51 @@
+// dxl_verify.h — DYNAMIXEL Status 応答の配達証明判定 (設計書 §4.2)。
+// Arduino 非依存 (native テスト可能)。生 I/O (txInstPacket/rxStatusPacket) と
+// param 組み立ては呼び出し側 (hw/dxl_backend.cpp) に残し、受理判定のみを
+// 抽出する (段階1a。docs/plans/2026-07-06-safety-core-extraction.md §3.1)。
+#pragma once
+
+#include <cstdint>
+
+namespace core {
+
+// Status 応答の観測値ビュー (ゲート1第1回指摘3対応 — rx==nullptr 時に呼び出し
+// 側でフィールドを deref させない。ライブラリ型 InfoToParseDXLPacket_t は
+// Arduino 依存のため core には持ち込まず、POD ビューに写して渡す)。
+struct DxlStatusView {
+  bool ok = false;          // rxStatusPacket() が nullptr でない
+  uint8_t id = 0;
+  uint8_t err_idx = 0;
+  uint16_t recv_param_len = 0;
+};
+
+// WRITE の Status 受理判定 (設計書 §4.2)。現行 dxl_backend.cpp:52-57 と逐語
+// 対応:
+//   !st.ok → 拒否 / id 不一致 → 拒否 / err_idx != 0 → 拒否 (ALERT 0x80 含む)
+//   / recv_param_len != 0 → 拒否 (前回 READ の遅延応答を配達証明として誤受理
+//   しない)
+// 限界 (§8 残余リスク): 同一 ID・err=0・recv_param_len=0 の遅延 WRITE Status
+// は本述語単体では判別不能で受理される (drainRx は tx 前の残留バイトのみ除去
+// し、tx 後に到着する遅延応答は防げない)。段階5 の transport タイムライン
+// テストでクローズする。
+inline bool isWriteStatusVerified(const DxlStatusView& st, uint8_t expect_id) {
+  if (!st.ok) return false;
+  if (st.id != expect_id) return false;
+  if (st.err_idx != 0) return false;
+  if (st.recv_param_len != 0) return false;
+  return true;
+}
+
+// READ の Status 受理判定。現行 dxl_backend.cpp:71-76 と逐語対応:
+//   !st.ok / id 不一致 / recv_param_len != expect_len → 拒否
+//   / (err_idx & 0x7F) != 0 → 拒否 (READ は ALERT ビットのみ許容 — HW エラー
+//   通知はヘルス側で扱う。Result Fail 等は拒否)
+inline bool isReadStatusVerified(const DxlStatusView& st, uint8_t expect_id,
+                                 uint16_t expect_len) {
+  if (!st.ok) return false;
+  if (st.id != expect_id) return false;
+  if (st.recv_param_len != expect_len) return false;
+  if ((st.err_idx & 0x7F) != 0) return false;
+  return true;
+}
+
+}  // namespace core

--- a/src/core/plausibility_monitor.h
+++ b/src/core/plausibility_monitor.h
@@ -1,0 +1,31 @@
+// plausibility_monitor.h — 電流妥当性監視 (設計書 §6)。Arduino 非依存
+// (内部状態は dwell_ のみ・I/O なし)。既に完全に純粋だったクラス本体を
+// tasks/control_task.cpp から逐語移動する (段階2。
+// docs/plans/2026-07-06-safety-core-extraction.md §3.3)。
+#pragma once
+
+#include <cmath>
+
+#include "../app_config.h"
+
+namespace core {
+
+// 電流妥当性監視 (§6): dwell 付きの単純な監視器
+class PlausibilityMonitor {
+ public:
+  // torque_on 中: |I_pres−I_cmd| 乖離、torque_off: 残留電流を監視
+  bool update(bool torque_on, bool fb_valid, float i_cmd, float i_pres, float dt) {
+    if (!fb_valid) return false;  // stale 帰還では判定しない
+    const float err = std::fabs(i_pres - i_cmd);
+    const bool bad = torque_on ? (err > cfg::kCurrentMismatchA)
+                               : (std::fabs(i_pres) > cfg::kCurrentResidualA);
+    dwell_ = bad ? (dwell_ + dt) : 0.0f;
+    return dwell_ > cfg::kCurrentPlausDwellS;
+  }
+  void reset() { dwell_ = 0.0f; }
+
+ private:
+  float dwell_ = 0.0f;
+};
+
+}  // namespace core

--- a/src/core/watchdog_policy.h
+++ b/src/core/watchdog_policy.h
@@ -1,0 +1,97 @@
+// watchdog_policy.h — Bus Watchdog 遷移表の判定 + 復旧頻度制限 (設計書 §4.3)。
+// Arduino 非依存 (native テスト可能)。I/O (raw98/Torque Enable の読取・
+// watchdogRecoverOne) は呼び出し側 (hw/dxl_backend.cpp) に残し、判断のみを
+// 抽出する (段階1b。docs/plans/2026-07-06-safety-core-extraction.md §3.2)。
+//
+// API 形状は逐次リデューサ (ゲート1第1回指摘2対応 — 現行 checkWatchdog は
+// 「rawL 読取失敗で即 return (rawR を読まない)」「teL 読取失敗で即 return
+// (teR を読まない)」という早期 return を持ち、『両輪分を読んでから一括判定』
+// の API では I/O 回数・順序の同一性が破れる。劣化経路でのバス往復・
+// タイムアウト遅延の増加は安全上許容しない)。
+#pragma once
+
+#include <cstdint>
+
+namespace core {
+
+enum class WatchdogVerdict : uint8_t { Pending, Ok, Fault, ProceedRecover };
+
+// 現行 checkWatchdog の判断列を I/O と同じ逐次順で消費するリデューサ。
+// call-site 契約: 読取 I/O は現行と同一順 (raw[L]→raw[R]→(トリップ時のみ)
+// te[L]→te[R]) で行い、各 feed が Pending 以外を返した時点で以降の I/O を
+// 行わない (早期 return の I/O 回数同一性)。逐語対応は現行 :374-388:
+//   feedRaw: 読取失敗 → torque_may_be_on ? Fault : Ok (即時) /
+//            両輪 feed 完了かつ非トリップ (いずれも != tripped_value) → Ok /
+//            トリップあり → Pending (TE 読取へ)
+//   feedTe:  読取失敗 → Fault (即時) / 両輪 feed 完了かつ両輪 0 →
+//            ProceedRecover / いずれか非零 → Fault (注: 現行 :388 は両輪
+//            読取後に te[0]!=0||te[1]!=0 を判定するため、teL 非零でも teR の
+//            読取は行われる。この I/O 回数も保存する — 非零検出は両輪 feed
+//            完了時に行う)
+//
+// 現行挙動の潜在エッジ (ゲート1第2回指摘で発見・本 PR では挙動保存):
+// 現行 :374-378 は「トリップ済み raw 値を観測した後に他輪の raw 読取が失敗」
+// しても、torque_may_be_on==false なら Ok を返す (既知のトリップ証拠が破棄
+// され、復旧も FAULT も発生しない)。本リデューサはこの挙動をそのまま保存
+// する (feedRaw の読取失敗判定は先行 raw 値に依存しない)。これはロジック
+// 変更ゼロ原則 (§2-1) による意図的判断であり、fail-closed 化 (トリップ証拠
+// 観測後の読取失敗を Fault 化) は別課題としてユーザへエスカレーション済み
+// (§8 残余リスク参照)。
+class WatchdogDecision {
+ public:
+  explicit WatchdogDecision(bool torque_may_be_on, uint8_t tripped_value)
+      : torque_may_be_on_(torque_may_be_on), tripped_value_(tripped_value) {}
+
+  // L→R の順で最大 2 回呼ぶ。Pending 以外を返した時点で以降呼ばない。
+  WatchdogVerdict feedRaw(bool read_ok, uint8_t value) {
+    ++raw_feed_count_;
+    if (!read_ok) {
+      // dt 起因検査で raw98 が読めない場合: トルク有効中なら fail-closed
+      return torque_may_be_on_ ? WatchdogVerdict::Fault : WatchdogVerdict::Ok;
+    }
+    if (value == tripped_value_) raw_tripped_ = true;
+    if (raw_feed_count_ < 2) return WatchdogVerdict::Pending;  // R 読取待ち
+    return raw_tripped_ ? WatchdogVerdict::Pending : WatchdogVerdict::Ok;
+  }
+
+  // L→R の順で最大 2 回呼ぶ (トリップ検出後のみ)。Pending 以外を返した時点で
+  // 以降呼ばない。
+  WatchdogVerdict feedTe(bool read_ok, uint8_t value) {
+    ++te_feed_count_;
+    if (!read_ok) return WatchdogVerdict::Fault;
+    if (value != 0) te_nonzero_ = true;
+    if (te_feed_count_ < 2) return WatchdogVerdict::Pending;  // R 読取待ち
+    return te_nonzero_ ? WatchdogVerdict::Fault : WatchdogVerdict::ProceedRecover;
+  }
+
+ private:
+  bool torque_may_be_on_;
+  uint8_t tripped_value_;
+  int raw_feed_count_ = 0;
+  bool raw_tripped_ = false;
+  int te_feed_count_ = 0;
+  bool te_nonzero_ = false;
+};
+
+// 復旧頻度制限 (60s 内 3 回で FAULT)。現行 :390-397 の recover_count_/
+// recover_window_start_s_ 状態機械を逐語移動 (リセット条件 count==0 ||
+// (now - start) > window、++count >= max で deny)。
+class WatchdogRecoverLimiter {
+ public:
+  // 復旧を許可するなら true。deny (= FAULT) 時も現行同様 count は増加済みの
+  // まま。
+  bool allow(float now_s, float window_s, int max_count) {
+    if (recover_count_ == 0 || (now_s - recover_window_start_s_) > window_s) {
+      recover_count_ = 0;
+      recover_window_start_s_ = now_s;
+    }
+    ++recover_count_;
+    return recover_count_ < max_count;
+  }
+
+ private:
+  int recover_count_ = 0;
+  float recover_window_start_s_ = 0.0f;
+};
+
+}  // namespace core

--- a/src/hw/dxl_backend.cpp
+++ b/src/hw/dxl_backend.cpp
@@ -3,7 +3,9 @@
 #include <Arduino.h>
 #include <cmath>
 
+#include "../core/dxl_verify.h"
 #include "../core/units.h"
+#include "../core/watchdog_policy.h"
 
 namespace hw {
 namespace {
@@ -49,13 +51,18 @@ bool DxlWithRxInfo::writeVerified(uint8_t id, uint16_t addr, const uint8_t* data
   }
   uint8_t rxbuf[32];
   const InfoToParseDXLPacket_t* rx = rxStatusPacket(rxbuf, sizeof(rxbuf), timeout_ms);
-  if (rx == nullptr) return false;
-  if (rx->id != id) return false;       // 他 ID/残留応答の誤消費を拒否 (§4.2)
-  if (rx->err_idx != 0) return false;   // ALERT(0x80) 含む非零は安全側へ
-  // WRITE の Status はパラメータ 0 バイト。前回 READ の遅延応答 (データ付き)
-  // を配達証明として誤受理しない
-  if (rx->recv_param_len != 0) return false;
-  return true;
+  // view 構築 (§3.1 call-site 契約: rx==nullptr 時にフィールドへ一切触れない。
+  // 引数評価は関数呼出し前に行われるため rx->field を引数式に書かない)
+  core::DxlStatusView st;
+  if (rx != nullptr) {
+    st.ok = true;
+    st.id = rx->id;
+    st.err_idx = rx->err_idx;
+    st.recv_param_len = rx->recv_param_len;
+  }
+  // 受理判定は core::isWriteStatusVerified へ抽出済み (段階1a。他 ID/残留
+  // 応答の誤消費・ALERT(0x80) 含む非零・前回 READ の遅延応答誤受理を拒否)
+  return core::isWriteStatusVerified(st, id);
 }
 
 bool DxlWithRxInfo::readVerified(uint8_t id, uint16_t addr, uint16_t len,
@@ -68,12 +75,20 @@ bool DxlWithRxInfo::readVerified(uint8_t id, uint16_t addr, uint16_t len,
   if (!txInstPacket(id, DXL_INST_READ, param, 4)) return false;
   uint8_t rxbuf[32];
   const InfoToParseDXLPacket_t* rx = rxStatusPacket(rxbuf, sizeof(rxbuf), timeout_ms);
-  if (rx == nullptr) return false;
-  if (rx->id != id) return false;
-  if (rx->recv_param_len != len) return false;
-  // READ の ALERT はデータ有効 (HW エラー通知はヘルス側で扱う) — err の
-  // ALERT ビット以外 (Instruction/CRC 等の Result Fail) は失敗扱い
-  if ((rx->err_idx & 0x7F) != 0) return false;
+  // view 構築 (§3.1 call-site 契約: rx==nullptr 時にフィールドへ一切触れない)
+  core::DxlStatusView st;
+  if (rx != nullptr) {
+    st.ok = true;
+    st.id = rx->id;
+    st.err_idx = rx->err_idx;
+    st.recv_param_len = rx->recv_param_len;
+  }
+  // 受理判定は core::isReadStatusVerified へ抽出済み (段階1a。READ の ALERT
+  // はデータ有効 — err の ALERT ビット以外 (Instruction/CRC 等の Result
+  // Fail) は失敗扱い)
+  if (!core::isReadStatusVerified(st, id, len)) return false;
+  // データコピーは成功時のみ実行 (現行と同順序。st.ok==true が保証されて
+  // いるためこの時点で rx は非 nullptr)
   for (uint16_t i = 0; i < len; ++i) buf[i] = rx->p_param_buf[i];
   return true;
 }
@@ -369,32 +384,37 @@ bool DxlBackend::watchdogRecoverOne(uint8_t id) {
 }
 
 WatchdogCheck DxlBackend::checkWatchdog(bool torque_may_be_on, float now_s) {
-  // §4.3: 判定根拠は両輪の実測 (raw98 + Torque Enable 読み戻し)
-  uint8_t wd[2];
-  for (int k = 0; k < 2; ++k) {
-    if (!readRaw(kIds[k], kAddrBusWatchdog, 1, &wd[k])) {
-      // dt 起因検査で raw98 が読めない場合: トルク有効中なら fail-closed
-      return torque_may_be_on ? WatchdogCheck::Fault : WatchdogCheck::Ok;
-    }
-  }
-  const bool tripped = (wd[0] == kWatchdogTripped) || (wd[1] == kWatchdogTripped);
-  if (!tripped) return WatchdogCheck::Ok;
+  // §4.3: 判定根拠は両輪の実測 (raw98 + Torque Enable 読み戻し)。判断は
+  // core::WatchdogDecision (逐次リデューサ) へ抽出済みで、ここは I/O の
+  // 位置・回数・順序を現行と同一に保つだけ (段階1b。
+  // docs/plans/2026-07-06-safety-core-extraction.md §3.2)。
+  core::WatchdogDecision decision(torque_may_be_on, kWatchdogTripped);
 
-  // Torque Enable 読み戻し (集約規則: 両輪成功かつ両輪 0 のみ自動復旧)
-  uint8_t te[2];
-  for (int k = 0; k < 2; ++k) {
-    if (!readRaw(kIds[k], kAddrTorqueEnable, 1, &te[k])) return WatchdogCheck::Fault;
+  // raw98 読取ループ: L→R の順、Pending 以外を返した時点で以降を読まない
+  // (早期 return の I/O 回数同一性)
+  core::WatchdogVerdict verdict = core::WatchdogVerdict::Pending;
+  for (int k = 0; k < 2 && verdict == core::WatchdogVerdict::Pending; ++k) {
+    uint8_t wd = 0;
+    const bool ok = readRaw(kIds[k], kAddrBusWatchdog, 1, &wd);
+    verdict = decision.feedRaw(ok, wd);
   }
-  if (te[0] != 0 || te[1] != 0) return WatchdogCheck::Fault;
+  if (verdict == core::WatchdogVerdict::Ok) return WatchdogCheck::Ok;
+  if (verdict == core::WatchdogVerdict::Fault) return WatchdogCheck::Fault;
 
-  // 復旧頻度制限 (60s 内 3 回で FAULT)
-  if (recover_count_ == 0 ||
-      (now_s - recover_window_start_s_) > cfg::kWatchdogRecoverWindowS) {
-    recover_count_ = 0;
-    recover_window_start_s_ = now_s;
+  // ここまで到達 = トリップ検出 (Pending)。Torque Enable 読み戻しへ
+  // (集約規則: 両輪成功かつ両輪 0 のみ自動復旧)。同様に L→R・早期打切り。
+  for (int k = 0; k < 2 && verdict == core::WatchdogVerdict::Pending; ++k) {
+    uint8_t te = 0;
+    const bool ok = readRaw(kIds[k], kAddrTorqueEnable, 1, &te);
+    verdict = decision.feedTe(ok, te);
   }
-  // 「60s 内 3 回で FAULT」= 自動復旧を許すのは 2 回まで、3 回目の発生で FAULT
-  if (++recover_count_ >= cfg::kWatchdogRecoverMaxCount) return WatchdogCheck::Fault;
+  if (verdict == core::WatchdogVerdict::Fault) return WatchdogCheck::Fault;
+
+  // verdict == ProceedRecover: 復旧頻度制限 (60s 内 3 回で FAULT)
+  if (!limiter_.allow(now_s, cfg::kWatchdogRecoverWindowS,
+                       cfg::kWatchdogRecoverMaxCount)) {
+    return WatchdogCheck::Fault;
+  }
 
   for (uint8_t id : kIds) {
     if (!watchdogRecoverOne(id)) return WatchdogCheck::Fault;

--- a/src/hw/dxl_backend.h
+++ b/src/hw/dxl_backend.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "../app_config.h"
+#include "../core/watchdog_policy.h"
 
 namespace hw {
 
@@ -107,9 +108,10 @@ class DxlBackend {
   uint8_t health_phase_ = 0;
   HealthInfo health_{};
   uint32_t tx_fail_count_ = 0;
-  // Watchdog 自動復旧の頻度制限 (§4.3: 60s 内 3 回で FAULT)
-  int recover_count_ = 0;
-  float recover_window_start_s_ = 0.0f;
+  // Watchdog 自動復旧の頻度制限 (§4.3: 60s 内 3 回で FAULT)。判断は
+  // core::WatchdogRecoverLimiter へ抽出済み (段階1b。
+  // docs/plans/2026-07-06-safety-core-extraction.md §3.2)。
+  core::WatchdogRecoverLimiter limiter_;
 };
 
 }  // namespace hw

--- a/src/tasks/control_task.cpp
+++ b/src/tasks/control_task.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <cmath>
 
+#include "../core/plausibility_monitor.h"
 #include "../core/units.h"
 
 namespace tasks {
@@ -11,26 +12,9 @@ namespace {
 using core::FaultReason;
 using core::FsmAction;
 using core::FsmState;
+using core::PlausibilityMonitor;
 
 float nowSeconds() { return static_cast<float>(esp_timer_get_time()) * 1e-6f; }
-
-// 電流妥当性監視 (§6): dwell 付きの単純な監視器
-class PlausibilityMonitor {
- public:
-  // torque_on 中: |I_pres−I_cmd| 乖離、torque_off: 残留電流を監視
-  bool update(bool torque_on, bool fb_valid, float i_cmd, float i_pres, float dt) {
-    if (!fb_valid) return false;  // stale 帰還では判定しない
-    const float err = std::fabs(i_pres - i_cmd);
-    const bool bad = torque_on ? (err > cfg::kCurrentMismatchA)
-                               : (std::fabs(i_pres) > cfg::kCurrentResidualA);
-    dwell_ = bad ? (dwell_ + dt) : 0.0f;
-    return dwell_ > cfg::kCurrentPlausDwellS;
-  }
-  void reset() { dwell_ = 0.0f; }
-
- private:
-  float dwell_ = 0.0f;
-};
 
 struct LoopState {
   core::AttitudeEstimator estimator;

--- a/test/test_core/test_main.cpp
+++ b/test/test_core/test_main.cpp
@@ -6,10 +6,14 @@
 
 #include "../../src/core/attitude_estimator.h"
 #include "../../src/core/balance_core.h"
+#include "../../src/core/dt_stats.h"
+#include "../../src/core/dxl_verify.h"
 #include "../../src/core/param_validation.h"
 #include "../../src/core/pid.h"
+#include "../../src/core/plausibility_monitor.h"
 #include "../../src/core/safety_fsm.h"
 #include "../../src/core/units.h"
+#include "../../src/core/watchdog_policy.h"
 
 #include <unity.h>
 
@@ -624,6 +628,448 @@ static void test_commissioning_fail_closed() {
   TEST_ASSERT_FALSE(validateCommissioning(rec, csum, 3));
 }
 
+// ---------------- dxl_verify (§4.2 配達証明。段階1a抽出) ----------------
+
+static DxlStatusView writeOkView(uint8_t id) {
+  DxlStatusView st;
+  st.ok = true;
+  st.id = id;
+  st.err_idx = 0;
+  st.recv_param_len = 0;
+  return st;
+}
+
+static void test_dxl_verify_write_accept_and_reject() {
+  // 受理: ID 一致・err=0・param_len=0
+  TEST_ASSERT_TRUE(isWriteStatusVerified(writeOkView(3), 3));
+
+  // 拒否1: st.ok=false (= rx nullptr の view。他フィールドは既定値のまま)
+  DxlStatusView st_no_rx;
+  TEST_ASSERT_FALSE(isWriteStatusVerified(st_no_rx, 3));
+
+  // 拒否2: ID 不一致
+  {
+    DxlStatusView st = writeOkView(3);
+    st.id = 4;
+    TEST_ASSERT_FALSE(isWriteStatusVerified(st, 3));
+  }
+  // 拒否3: err_idx=0x80 (ALERT も含め非零は拒否)
+  {
+    DxlStatusView st = writeOkView(3);
+    st.err_idx = 0x80;
+    TEST_ASSERT_FALSE(isWriteStatusVerified(st, 3));
+  }
+  // 拒否4: err_idx=0x01 (Result Fail 等)
+  {
+    DxlStatusView st = writeOkView(3);
+    st.err_idx = 0x01;
+    TEST_ASSERT_FALSE(isWriteStatusVerified(st, 3));
+  }
+  // 拒否5: recv_param_len != 0 (前回 READ の遅延応答の誤受理拒否)
+  {
+    DxlStatusView st = writeOkView(3);
+    st.recv_param_len = 2;
+    TEST_ASSERT_FALSE(isWriteStatusVerified(st, 3));
+  }
+
+  // 述語の限界の明示 (§8 残余リスク): 同一 ID・err=0・param_len=0 の遅延
+  // WRITE Status は述語単体では判別不能で受理される (現行実装と同一の挙動。
+  // drainRx は tx 前の残留バイトのみ除去し、tx 後に到着する遅延応答は防げ
+  // ない)。段階5 の transport タイムラインテストでクローズするまでの残余
+  // リスクとしてここに明示する — writeOkView(3) は「本来の Status」と
+  // 「同一 ID の遅延応答」を型として区別できないため、両者とも受理される。
+  TEST_ASSERT_TRUE(isWriteStatusVerified(writeOkView(3), 3));
+}
+
+static DxlStatusView readOkView(uint8_t id, uint16_t len, uint8_t err_idx = 0) {
+  DxlStatusView st;
+  st.ok = true;
+  st.id = id;
+  st.err_idx = err_idx;
+  st.recv_param_len = len;
+  return st;
+}
+
+static void test_dxl_verify_read_accept_and_reject() {
+  // 受理: err=0
+  TEST_ASSERT_TRUE(isReadStatusVerified(readOkView(5, 2), 5, 2));
+  // 受理: ALERT のみ (0x80) は現行仕様どおりデータ有効
+  TEST_ASSERT_TRUE(isReadStatusVerified(readOkView(5, 2, 0x80), 5, 2));
+
+  // 拒否1: rx 失敗 (st.ok=false)
+  {
+    DxlStatusView st;
+    TEST_ASSERT_FALSE(isReadStatusVerified(st, 5, 2));
+  }
+  // 拒否2: ID 不一致
+  {
+    DxlStatusView st = readOkView(5, 2);
+    st.id = 6;
+    TEST_ASSERT_FALSE(isReadStatusVerified(st, 5, 2));
+  }
+  // 拒否3: 長さ不一致
+  TEST_ASSERT_FALSE(isReadStatusVerified(readOkView(5, 1), 5, 2));
+  // 拒否4: Result Fail (err & 0x7F != 0)。ALERT と重畳した 0x81 も拒否
+  TEST_ASSERT_FALSE(isReadStatusVerified(readOkView(5, 2, 0x01), 5, 2));
+  TEST_ASSERT_FALSE(isReadStatusVerified(readOkView(5, 2, 0x81), 5, 2));
+}
+
+// ---------------- watchdog_policy (§4.3 遷移表。段階1b抽出) ----------------
+
+static constexpr uint8_t kTestTripped = 0xFF;
+
+static void test_watchdog_raw_read_failure_confirms_immediately() {
+  // rawL 読取失敗: 1 回目の feedRaw で即確定 (rawR を feed しない)
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Fault),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/false, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Ok),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+  // rawR 読取失敗: 2 回目で即確定 (1 回目は非トリップの正常読取)
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Fault),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/false, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Ok),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+}
+
+static void test_watchdog_raw_trip_combinations() {
+  // 両輪非トリップ → 2 回目の feedRaw で Ok
+  {
+    WatchdogDecision d(true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Ok),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+  }
+  // トリップ L のみ → 2 回目の feedRaw で Pending (TE 段階へ)
+  {
+    WatchdogDecision d(true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+  }
+  // トリップ R のみ
+  {
+    WatchdogDecision d(true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, 0x00)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+  }
+  // 両輪トリップ
+  {
+    WatchdogDecision d(true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+  }
+}
+
+static void test_watchdog_te_read_failure_confirms_immediately() {
+  // teL 読取失敗: 1 回目の feedTe で即 Fault (teR を feed しない)
+  {
+    WatchdogDecision d(true, kTestTripped);
+    d.feedRaw(true, kTestTripped);
+    d.feedRaw(true, 0x00);  // トリップ確定 → Pending (TE 段階へ)
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Fault),
+                       static_cast<int>(d.feedTe(false, 0)));
+  }
+  // teR 読取失敗: 2 回目で Fault (1 回目は正常読取)
+  {
+    WatchdogDecision d(true, kTestTripped);
+    d.feedRaw(true, kTestTripped);
+    d.feedRaw(true, 0x00);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedTe(true, 0)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Fault),
+                       static_cast<int>(d.feedTe(false, 0)));
+  }
+}
+
+static void test_watchdog_te_value_combinations() {
+  // (teL,teR) 全組合せ (ゲート1第3回指摘対応: 現行 te[0]!=0||te[1]!=0 の OR
+  // 意味論が && へ写し間違えられても検出できるよう全組合せを固定)。
+  // 2 回目の feedTe 完了時に確定 (1 回目は teL 非零でも Pending = teL 非零
+  // でも teR 読取まで行う現行 I/O 順序契約を同じテストで固定)。
+  struct Case { uint8_t te_l, te_r; WatchdogVerdict expect; };
+  const Case cases[] = {
+      {1, 0, WatchdogVerdict::Fault},
+      {0, 1, WatchdogVerdict::Fault},
+      {1, 1, WatchdogVerdict::Fault},
+      {0, 0, WatchdogVerdict::ProceedRecover},
+  };
+  for (const auto& c : cases) {
+    WatchdogDecision d(true, kTestTripped);
+    d.feedRaw(true, kTestTripped);
+    d.feedRaw(true, 0x00);  // トリップ確定 → Pending
+    const WatchdogVerdict v1 = d.feedTe(true, c.te_l);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(v1));  // 1 回目は常に Pending
+    const WatchdogVerdict v2 = d.feedTe(true, c.te_r);
+    TEST_ASSERT_EQUAL(static_cast<int>(c.expect), static_cast<int>(v2));
+  }
+}
+
+static void test_watchdog_characterization_trip_then_raw_read_failure() {
+  // 現行挙動の特性化 (§3.2 潜在エッジ・§8 残余リスク): rawL=0xFF (トリップ)
+  // を観測した直後に rawR の読取が失敗すると、先行トリップ証拠は結果に
+  // 影響せず torque_may_be_on の値のみで確定する (false→Ok / true→Fault)。
+  // これは現行 dxl_backend.cpp:374-378 と同一の残余リスクであり、
+  // fail-closed 化 (トリップ証拠観測後の読取失敗を Fault 化) は別課題として
+  // ユーザへエスカレーション済み (安全挙動変更のためユーザ判断が必要)。
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/false, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Ok),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+  {
+    WatchdogDecision d(/*torque_may_be_on=*/true, kTestTripped);
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Pending),
+                       static_cast<int>(d.feedRaw(true, kTestTripped)));
+    TEST_ASSERT_EQUAL(static_cast<int>(WatchdogVerdict::Fault),
+                       static_cast<int>(d.feedRaw(false, 0)));
+  }
+}
+
+static void test_watchdog_recover_limiter_window_and_deny() {
+  const float window_s = 60.0f;
+  const int max_count = 3;
+
+  // 窓内 2 回目まで allow・3 回目 deny・deny 後も窓内は deny 継続
+  {
+    WatchdogRecoverLimiter lim;
+    TEST_ASSERT_TRUE(lim.allow(0.0f, window_s, max_count));
+    TEST_ASSERT_TRUE(lim.allow(10.0f, window_s, max_count));
+    TEST_ASSERT_FALSE(lim.allow(20.0f, window_s, max_count));
+    TEST_ASSERT_FALSE(lim.allow(30.0f, window_s, max_count));  // deny 継続
+  }
+
+  // 境界: ちょうど window_s は同一窓 (> 比較なので == はリセットしない)
+  {
+    WatchdogRecoverLimiter lim;
+    TEST_ASSERT_TRUE(lim.allow(0.0f, window_s, max_count));       // count=1
+    TEST_ASSERT_TRUE(lim.allow(window_s, window_s, max_count));   // count=2 (同一窓)
+    TEST_ASSERT_FALSE(lim.allow(window_s, window_s, max_count));  // count=3 → deny
+  }
+
+  // 境界: window_s+ε で新窓 (リセット)
+  {
+    WatchdogRecoverLimiter lim;
+    TEST_ASSERT_TRUE(lim.allow(0.0f, window_s, max_count));               // count=1
+    TEST_ASSERT_TRUE(lim.allow(window_s * 0.5f, window_s, max_count));    // count=2
+    TEST_ASSERT_FALSE(lim.allow(window_s * 0.9f, window_s, max_count));   // count=3 → deny (同一窓)
+    TEST_ASSERT_TRUE(lim.allow(window_s + 0.001f, window_s, max_count));  // 新窓 → count=1 → allow
+  }
+}
+
+// ---------------- plausibility_monitor (§6。段階2逐語移動) ----------------
+
+static void test_plausibility_fb_invalid_no_judge() {
+  PlausibilityMonitor pm;
+  // fb_valid=false: 判定しない・dwell 非蓄積
+  for (int i = 0; i < 100; ++i) {
+    TEST_ASSERT_FALSE(pm.update(/*torque_on=*/true, /*fb_valid=*/false, 0.0f, 1.0f, 0.005f));
+  }
+}
+
+static void test_plausibility_torque_on_dwell_threshold() {
+  PlausibilityMonitor pm;
+  const float dt = cfg::kCurrentPlausDwellS;  // 1 周期でちょうど閾値相当の dt
+  // err = |1.0-0.5| = 0.5 > kCurrentMismatchA(0.3) なので bad
+  // 1 回目: dwell = 0+dt == 閾値 (ちょうど、ビット同一) → > 比較で false (境界)
+  TEST_ASSERT_FALSE(pm.update(true, true, 0.5f, 1.0f, dt));
+  // 2 回目: dwell = 2*閾値 > 閾値 → true
+  TEST_ASSERT_TRUE(pm.update(true, true, 0.5f, 1.0f, dt));
+}
+
+static void test_plausibility_recovery_resets_dwell() {
+  PlausibilityMonitor pm;
+  const float dt = cfg::kCurrentPlausDwellS;
+  TEST_ASSERT_FALSE(pm.update(true, true, 0.5f, 1.0f, dt));  // dwell=閾値 (bad)
+  // 正常に戻る (err=0) → dwell リセット
+  TEST_ASSERT_FALSE(pm.update(true, true, 1.0f, 1.0f, dt));
+  // 良好状態直後にもう一度悪化させても、まだ 1 周期分の dwell しか無い
+  TEST_ASSERT_FALSE(pm.update(true, true, 0.5f, 1.0f, dt));
+}
+
+static void test_plausibility_torque_off_residual_and_reset() {
+  PlausibilityMonitor pm;
+  const float dt = cfg::kCurrentPlausDwellS;
+  // torque_off: |i_pres| > kCurrentResidualA(0.1) で bad
+  TEST_ASSERT_FALSE(pm.update(false, true, 0.0f, 0.2f, dt));  // dwell=閾値ちょうど
+  TEST_ASSERT_TRUE(pm.update(false, true, 0.0f, 0.2f, dt));   // 超過
+  pm.reset();
+  // reset 後は dwell 0 から再スタート。残留電流が閾値内なら bad にならない
+  TEST_ASSERT_FALSE(pm.update(false, true, 0.0f, 0.05f, dt));
+}
+
+// ---------------- dt_stats (§6 soak gate 計算コア。段階3新設) ----------------
+
+static void test_dtstats_p95_n0_fails_closed() {
+  DtP95Window w;
+  float v = 12.34f;  // 番兵値
+  TEST_ASSERT_FALSE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, 12.34f, v);  // *out 不変
+}
+
+static void test_dtstats_n1() {
+  DtP95Window w;
+  w.add(0.005f);
+  float v = -1.0f;
+  TEST_ASSERT_TRUE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.005f, v);
+}
+
+static void test_dtstats_n20_known_distribution() {
+  DtP95Window w;
+  // 値 1..20 を投入。nearest-rank: idx = ceil(0.95*20)-1 = 18 (0-indexed)
+  // = 昇順 19 番目の値 = 19
+  for (int i = 1; i <= 20; ++i) w.add(static_cast<float>(i));
+  float v = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6f, 19.0f, v);
+}
+
+static void test_dtstats_unsorted_and_duplicate_input() {
+  DtP95Window w;
+  // {1..20} の多重集合だが 17 を欠落させ 19 を重複させた (合計 20 個)。
+  // ソート後: 1,2,...,16,18,19,19,20 → idx=18 (0-indexed) = 19
+  const float vals[] = {5, 1, 20, 3, 19, 19, 2, 18, 4, 6,
+                        7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  for (float x : vals) w.add(x);
+  float v = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6f, 19.0f, v);
+}
+
+static void test_dtstats_p95_preserves_input_order() {
+  DtP95Window w;
+  w.add(3.0f);
+  w.add(1.0f);
+  w.add(2.0f);
+  float v1 = 0.0f, v2 = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v1));
+  // 同一呼出しを繰り返しても同じ値 (内部作業配列で選択・buf_ は非破壊)
+  TEST_ASSERT_TRUE(w.p95(&v2));
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, v1, v2);
+  // 呼出し後も add を継続でき、新規サンプルを含めた計算が正しく行われる
+  w.add(0.5f);
+  TEST_ASSERT_EQUAL(4, static_cast<int>(w.size()));
+  float v3 = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v3));
+  // n=4: idx = ceil(0.95*4)-1 = ceil(3.8)-1 = 4-1 = 3 → 最大値 (3.0)
+  TEST_ASSERT_FLOAT_WITHIN(1e-6f, 3.0f, v3);
+}
+
+static void test_dtstats_n400_soak_window() {
+  DtP95Window w;
+  for (int i = 0; i < 400; ++i) w.add(0.005f);  // 200Hz×2s の均一 dt
+  TEST_ASSERT_EQUAL(400, static_cast<int>(w.size()));
+  TEST_ASSERT_FALSE(w.overflowed());
+  TEST_ASSERT_TRUE(w.ready(400));
+  float v = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.005f, v);
+}
+
+static void test_dtstats_ready_boundary() {
+  DtP95Window w399;
+  for (int i = 0; i < 399; ++i) w399.add(0.001f);
+  TEST_ASSERT_FALSE(w399.ready(400));
+
+  DtP95Window w400;
+  for (int i = 0; i < 400; ++i) w400.add(0.001f);
+  TEST_ASSERT_TRUE(w400.ready(400));
+}
+
+static void test_dtstats_capacity_overflow_keeps_existing_samples() {
+  DtP95Window w;
+  for (size_t i = 0; i < DtP95Window::kCapacity; ++i) w.add(0.005f);  // ちょうど満杯
+  TEST_ASSERT_EQUAL(static_cast<int>(DtP95Window::kCapacity), static_cast<int>(w.size()));
+  TEST_ASSERT_FALSE(w.overflowed());
+
+  // 満杯後の追加は記録されず overflowed が立つ (既存サンプルは変化しない)
+  w.add(0.999f);
+  TEST_ASSERT_EQUAL(static_cast<int>(DtP95Window::kCapacity), static_cast<int>(w.size()));
+  TEST_ASSERT_TRUE(w.overflowed());
+  float v = 0.0f;
+  TEST_ASSERT_TRUE(w.p95(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.005f, v);  // 0.999 は含まれない
+  TEST_ASSERT_FALSE(w.ready(1));  // overflow → ready は常に false
+}
+
+static void test_dtstats_reset() {
+  DtP95Window w;
+  w.add(1.0f);
+  w.add(2.0f);
+  w.reset();
+  TEST_ASSERT_EQUAL(0, static_cast<int>(w.size()));
+  TEST_ASSERT_FALSE(w.overflowed());
+  float v = 0.0f;
+  TEST_ASSERT_FALSE(w.p95(&v));  // n==0 → false・*out 不変
+  TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, v);
+  w.add(3.0f);
+  TEST_ASSERT_EQUAL(1, static_cast<int>(w.size()));
+}
+
+static void test_dtstats_fail_closed_gate_table() {
+  // 「ready && p95 && v<=budget」合成ゲートが空窓・不足窓・溢れ窓で合格し
+  // 得ないことのテーブルテスト。
+  const float budget = 0.010f;
+
+  // 空窓
+  {
+    DtP95Window w;
+    float v = 0.0f;
+    const bool gate = w.ready(400) && w.p95(&v) && v <= budget;
+    TEST_ASSERT_FALSE(gate);
+  }
+  // 不足窓 (n=399 < min_samples=400)
+  {
+    DtP95Window w;
+    for (int i = 0; i < 399; ++i) w.add(0.001f);
+    float v = 0.0f;
+    const bool gate = w.ready(400) && w.p95(&v) && v <= budget;
+    TEST_ASSERT_FALSE(gate);
+  }
+  // ちょうど 400 (予算内) → 合格
+  {
+    DtP95Window w;
+    for (int i = 0; i < 400; ++i) w.add(0.001f);
+    float v = 0.0f;
+    const bool gate = w.ready(400) && w.p95(&v) && v <= budget;
+    TEST_ASSERT_TRUE(gate);
+  }
+  // 溢れ窓 (overflow) → ready は常に false
+  {
+    DtP95Window w;
+    for (size_t i = 0; i < DtP95Window::kCapacity; ++i) w.add(0.001f);
+    w.add(0.001f);  // 溢れ
+    float v = 0.0f;
+    const bool gate = w.ready(1) && w.p95(&v) && v <= budget;
+    TEST_ASSERT_FALSE(gate);
+  }
+}
+
 // ---------------- runner ----------------
 
 int main(int, char**) {
@@ -660,5 +1106,27 @@ int main(int, char**) {
   RUN_TEST(test_params_defaults_valid);
   RUN_TEST(test_commissioning_fail_closed);
   RUN_TEST(test_fsm_entry_failed);
+  RUN_TEST(test_dxl_verify_write_accept_and_reject);
+  RUN_TEST(test_dxl_verify_read_accept_and_reject);
+  RUN_TEST(test_watchdog_raw_read_failure_confirms_immediately);
+  RUN_TEST(test_watchdog_raw_trip_combinations);
+  RUN_TEST(test_watchdog_te_read_failure_confirms_immediately);
+  RUN_TEST(test_watchdog_te_value_combinations);
+  RUN_TEST(test_watchdog_characterization_trip_then_raw_read_failure);
+  RUN_TEST(test_watchdog_recover_limiter_window_and_deny);
+  RUN_TEST(test_plausibility_fb_invalid_no_judge);
+  RUN_TEST(test_plausibility_torque_on_dwell_threshold);
+  RUN_TEST(test_plausibility_recovery_resets_dwell);
+  RUN_TEST(test_plausibility_torque_off_residual_and_reset);
+  RUN_TEST(test_dtstats_p95_n0_fails_closed);
+  RUN_TEST(test_dtstats_n1);
+  RUN_TEST(test_dtstats_n20_known_distribution);
+  RUN_TEST(test_dtstats_unsorted_and_duplicate_input);
+  RUN_TEST(test_dtstats_p95_preserves_input_order);
+  RUN_TEST(test_dtstats_n400_soak_window);
+  RUN_TEST(test_dtstats_ready_boundary);
+  RUN_TEST(test_dtstats_capacity_overflow_keeps_existing_samples);
+  RUN_TEST(test_dtstats_reset);
+  RUN_TEST(test_dtstats_fail_closed_gate_table);
   return UNITY_END();
 }


### PR DESCRIPTION
## 概要

監査（2026-07-04）の HIGH「安全機構のmockテスト未実装」・MEDIUM「dt p95 soak gate未実装」への段階的対応の第1弾（段階1〜3、ユーザ承認済み）。設計の正は `docs/plans/2026-07-06-safety-core-extraction.md`（本PRに同梱、ゲート1 4ラウンドapprove済み）。

**ロジック変更ゼロ**: 判定条件・比較演算子・境界値・状態更新順序・I/Oの位置/回数/順序を一切変えない純関数抽出のみ。

## 内容

| 段階 | 新規ファイル | 内容 |
|---|---|---|
| 1a | `src/core/dxl_verify.h` | 配達証明の受理述語（`DxlStatusView` + WRITE/READ判定。nullptrガードのcall-site契約付き） |
| 1b | `src/core/watchdog_policy.h` | Bus Watchdog逐次リデューサ（feedRaw/feedTe、早期returnのI/O回数を保存）+ 復旧頻度制限（60s内3回でFAULT）の状態機械 |
| 2 | `src/core/plausibility_monitor.h` | `PlausibilityMonitor` を control_task.cpp から逐語移設 |
| 3 | `src/core/dt_stats.h` | `DtP95Window`（fail-closed API・nearest-rank・heap不使用。**本PRでは未結線** — INITIALIZINGへのゲート結線は段階4） |

nativeテスト **22本追加（32→54）**: 境界値・左右非対称の全組合せ（TE (0,0)/(1,0)/(0,1)/(1,1) の確定タイミング込み）・現行挙動の特性化・DtP95Windowのfail-closedテーブル。

## 検証

- `pio test -e native`: **54/54 PASS**（回帰ゼロ）
- `pio run -e m5stack-core2`: SUCCESS（RAM 0.6% / Flash 8.2%）
- 抽出前後の逐語対応を実装エージェント自己対査 + メインセッション監査 + ゲート2で三重対査

## レビュー実績

- ゲート1（/codex:adversarial-review）: **4ラウンド・7指摘反映で approve**
- ゲート2（/codex:review）: **1回目で指摘なし**（「introduced behavior changes なし・抽出は原制御フローと一致」）

## エスカレーション（現行実装の潜在エッジ2件 — 本PRは挙動保存、修正は別課題）

1. **トリップ観測後の他輪raw読取失敗**: `checkWatchdog` はrawL=0xFF（トリップ）観測後にrawR読取が失敗すると、torque-off経路では Ok を返し既知のトリップ証拠を破棄する（旧 `dxl_backend.cpp:374-378` の早期return意味論）。fail-closed化はユーザ判断+独立レビューが必要な安全挙動変更のため見送り、特性化テストで現行挙動を固定した。
2. **同一ID・err=0・param_len=0 の遅延WRITE Status**: 述語では判別不能（drainRxはtx前の残留のみ除去）。段階5のtransportタイムラインテストでクローズ予定。限界を明示するテストを同梱。

## 今後（承認済みロードマップ）

- 段階4: control_task周期本体の関数抽出 + p95ゲートのIDLE遷移結線（別PR）
- 段階5: transport抽象化による残り3テスト（検疫沈黙・未検証トルク窓・保存/アームレース）の完全カバー（別PR）

**PR #27 との合流時**: `control_task.cpp` を両系列が編集するが領域が異なる（本PRは冒頭のクラス削除、#27はLoopState/publish部）ため競合は自明に解消可能な見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)