### PR TITLE
実機ブリングアップ: コミッショニング機構削除とDXLバス実機適合

### DIFF
--- a/src/app_config.h
+++ b/src/app_config.h
@@ -16,7 +16,7 @@ constexpr int      kDtFaultConsecutive = 5;
 // ---- ハードウェア (PORT A / DYNAMIXEL) ----
 constexpr uint8_t  kPinRxServo = 33;
 constexpr uint8_t  kPinTxServo = 32;
-constexpr uint32_t kDxlBaud    = 1000000;
+constexpr uint32_t kDxlBaud    = 1000000;  // サーボ EEPROM 設定値と一致必須 (README 手順で 1M 化済み)
 constexpr uint8_t  kDxlIdLeft  = 0;
 constexpr uint8_t  kDxlIdRight = 1;
 constexpr uint16_t kDxlModelNumber = 1190; // XL330-M077
@@ -47,7 +47,8 @@ constexpr int   kImuStaleFaultCycles = 5;     // gyro stale 連続 25ms で FAUL
 // ---- DXL 通信規律 (§4.2) ----
 constexpr uint32_t kDxlIoTimeoutMs        = 2;   // 全トランザクション明示タイムアウト
 constexpr float    kDxlCycleBudgetS       = 0.003f; // 1周期内 DXL 総予算 3ms
-constexpr int      kDxlReadStaleFaultCycles = 4; // 読取失敗 連続 20ms で FAULT
+constexpr int      kDxlReadStaleFaultCycles = 40; // 読取失敗 連続 200ms で FAULT
+// (実バスは読取が単発で落ちる。失敗周期はコースト(§4.2)なので 200ms まで許容)
 constexpr float    kUnverifiedTorqueMaxS  = 0.010f; // 未検証トルク窓 (壁時計)
 constexpr uint8_t  kBusWatchdogRaw        = 1;   // 20ms (raw 1 = 最小)
 constexpr float    kBusWatchdogWindowS    = 0.020f;
@@ -56,8 +57,7 @@ constexpr int      kWatchdogRecoverMaxCount = 3;  // 60s 内 3 回で FAULT
 constexpr float    kWatchdogRecoverWindowS  = 60.0f;
 
 // ---- 電流制限 3 層 + I²t (§2.3) ----
-constexpr float kCurrentLimitNormalA  = 0.900f; // EEPROM Current Limit(38) TUNE
-constexpr float kCurrentLimitBringupA = 0.150f; // ブリングアップ・プロファイル
+constexpr float kCurrentLimitA        = 0.900f; // EEPROM Current Limit(38) TUNE
 constexpr float kCurrentPeakA         = 0.450f; // ソフトピーク TUNE
 constexpr float kCurrentContA         = 0.300f; // ソフト連続 TUNE
 constexpr float kPeakDurationS        = 0.5f;   // I²t: E_max=(Ip²-Ic²)*Tpeak TUNE
@@ -89,10 +89,9 @@ constexpr float kFallThresholdRad    = 0.611f;  // 35°
 constexpr float kStartWindowRad      = 0.0873f; // 5°
 constexpr float kStartRateMaxRadS    = 0.35f;   // ~20°/s
 constexpr float kStartWheelMaxRadS   = 1.0f;
-constexpr float kUprightHoldS        = 1.0f;    // 起立/静置検出の保持時間
+constexpr float kUprightHoldS        = 0.5f;    // 起立/静置検出の保持時間
 constexpr int   kFallEscalationCount = 3;       // 30s 内 3 回で FAULT ラッチ
 constexpr float kFallEscalationWindowS = 30.0f;
-constexpr bool  kAutoArmOnBootDefault  = true;  // コミッショニング後のみ有効 (Q5)
 
 // ---- ヘルス監視閾値 ----
 constexpr float kVoltageMinV   = 3.6f;  // AAA×3 のサグ考慮 TUNE
@@ -104,7 +103,6 @@ constexpr uint32_t kBtnLongPressMs    = 1000; // BtnC STOP/ARM トグル
 
 // ---- NVS レコード (§9.1) ----
 constexpr uint16_t kParamSchemaVersion       = 1;
-constexpr uint16_t kCommissionSchemaVersion  = 1;
 
 // ---- パラメータ許容範囲 [min, max] (§9.1 範囲検証。1つでも外れたら全体破棄) ----
 struct ParamRange { float min; float max; };
@@ -115,11 +113,5 @@ constexpr ParamRange kRangeKv        {0.0f, 1.0f};
 constexpr ParamRange kRangeKvi       {0.0f, 1.0f};
 constexpr ParamRange kRangePitchEq   {-0.35f, 0.35f}; // ±20°
 constexpr ParamRange kRangeThetaRefLimit {0.0f, 0.175f}; // ±10°
-
-// ---- プロファイル (§4.1) ----
-enum class Profile : uint8_t { Bringup = 0, Normal = 1 };
-constexpr float currentLimitFor(Profile p) {
-  return p == Profile::Bringup ? kCurrentLimitBringupA : kCurrentLimitNormalA;
-}
 
 }  // namespace cfg

--- a/src/core/param_validation.h
+++ b/src/core/param_validation.h
@@ -1,4 +1,4 @@
-// param_validation.h — NVS レコード検証 (設計書 §9.1) + コミッショニング認可 (§6)。
+// param_validation.h — NVS レコード検証 (設計書 §9.1)。
 // 純関数・fail-closed: 版不一致/範囲外が 1 つでもあれば全体破棄して既定値へ。
 #pragma once
 
@@ -35,56 +35,6 @@ inline bool validateParams(const TuningParams& rec) {
   if (!inRange(rec.kvi, cfg::kRangeKvi)) return false;
   if (!inRange(rec.pitch_eq, cfg::kRangePitchEq)) return false;
   if (!inRange(rec.theta_ref_limit, cfg::kRangeThetaRefLimit)) return false;
-  return true;
-}
-
-// コミッショニング認可レコード (§6): fail-closed。
-// sign_axis_checksum はファーム側の符号/軸定数から毎回計算して照合する。
-struct CommissioningRecord {
-  uint16_t schema_version = 0;
-  uint8_t profile = 0;              // cfg::Profile
-  uint32_t sign_axis_checksum = 0;  // 符号/軸 config のチェックサム
-  uint16_t calib_version = 0;       // pitch_eq 校正レコードの版
-  bool user_confirmed = false;
-};
-
-// 現在のファーム構成から符号/軸チェックサムを計算 (FNV-1a 32bit)。
-// コミッショニング (符号試験合格) が保証するのは車輪符号と IMU 軸/符号の両方
-// なので、どちらが変わっても記録を無効化する (§6 fail-closed)。
-inline uint32_t signAxisChecksum(float sign_left, float sign_right,
-                                 float imu_tilt_sign, float imu_vert_sign,
-                                 float imu_gyro_sign) {
-  uint32_t h = 2166136261u;
-  auto mix = [&h](uint32_t v) {
-    for (int i = 0; i < 4; ++i) {
-      h ^= (v >> (i * 8)) & 0xFFu;
-      h *= 16777619u;
-    }
-  };
-  // 符号は -1/+1 のみ想定 → 整数化して混ぜる (浮動小数のビット差を避ける)
-  mix(sign_left < 0.0f ? 0xFFFFFFFFu : 1u);
-  mix(sign_right < 0.0f ? 0xFFFFFFFFu : 1u);
-  mix(imu_tilt_sign < 0.0f ? 0xFFFFFFFFu : 1u);
-  mix(imu_vert_sign < 0.0f ? 0xFFFFFFFFu : 1u);
-  mix(imu_gyro_sign < 0.0f ? 0xFFFFFFFFu : 1u);
-  return h;
-}
-
-// 現行 config 一式からのチェックサム (呼び出し箇所の引数ミスマッチを防ぐ)
-inline uint32_t currentSignAxisChecksum() {
-  return signAxisChecksum(cfg::kSignLeft, cfg::kSignRight, cfg::kImuAccTiltSign,
-                          cfg::kImuAccVertSign, cfg::kImuGyroSign);
-}
-
-// true = コミッショニング済みとして auto-arm を許可してよい
-inline bool validateCommissioning(const CommissioningRecord& rec,
-                                  uint32_t current_sign_axis_checksum,
-                                  uint16_t current_calib_version) {
-  if (rec.schema_version != cfg::kCommissionSchemaVersion) return false;
-  if (rec.profile != static_cast<uint8_t>(cfg::Profile::Normal)) return false;
-  if (rec.sign_axis_checksum != current_sign_axis_checksum) return false;
-  if (rec.calib_version != current_calib_version) return false;
-  if (!rec.user_confirmed) return false;
   return true;
 }
 

--- a/src/core/safety_fsm.h
+++ b/src/core/safety_fsm.h
@@ -50,8 +50,6 @@ class SafetyFsm {
     float fall_threshold_rad = 0.611f;
     int fall_escalation_count = 3;
     float fall_escalation_window_s = 30.0f;
-    bool auto_arm = true;      // コミッショニング済みの場合のみ有効
-    bool commissioned = false; // 未コミッショニングなら明示アーム必須
   };
 
   struct Input {
@@ -78,10 +76,10 @@ class SafetyFsm {
   FaultReason faultReason() const { return fault_reason_; }
   int fallCount() const { return fall_count_; }
 
-  // INITIALIZING 完了 (自己検査含む) の報告。auto-arm ゲート (§6) を適用。
+  // INITIALIZING 完了 (自己検査含む) の報告。
   void notifyInitDone() {
     if (state_ != FsmState::Initializing) return;
-    state_ = (p_.commissioned && p_.auto_arm) ? FsmState::Idle : FsmState::Disarmed;
+    state_ = FsmState::Idle;
   }
 
   // enter_balancing() の実行結果報告
@@ -173,7 +171,7 @@ class SafetyFsm {
 
       case FsmState::Disarmed: {
         if (in.stop_toggle) {
-          // 明示アーム (BtnC): コミッショニング前でも許可 (ブリングアップ経路)
+          // 明示アーム (BtnC)
           if (!in.save_in_progress) {
             state_ = FsmState::Idle;
             upright_since_valid_ = false;
@@ -198,9 +196,13 @@ class SafetyFsm {
   static float fabsf_(float v) { return v < 0.0f ? -v : v; }
 
   bool uprightHold(const Input& in) {
+    // 読取欠落周期は「情報なし」としてタイマを維持する (実バスは数%の率で
+    // 単発の読取落ちがあり、リセットすると保持時間の連続成立がほぼ不可能)。
+    // 帰還が死んだままなら DxlReadStale が先に FAULT させるため安全側は保たれる
+    if (!in.wheel_valid) return false;
     const bool ok = fabsf_(in.theta) < p_.start_window_rad &&
                     fabsf_(in.theta_rate) < p_.start_rate_max &&
-                    in.wheel_valid && in.wheel_speed_max < p_.start_wheel_max;
+                    in.wheel_speed_max < p_.start_wheel_max;
     if (!ok) {
       upright_since_valid_ = false;
       return false;

--- a/src/hw/dxl_backend.cpp
+++ b/src/hw/dxl_backend.cpp
@@ -11,6 +11,10 @@ namespace {
 // XL330 制御テーブル (XL330規範 §6.1)
 constexpr uint16_t kAddrModelNumber = 0;
 constexpr uint16_t kAddrReturnDelay = 9;
+// Return Delay Time raw (2µs 単位)。0 だと片線ハーフデュプレクス配線の
+// ターンアラウンドで応答先頭バイトが化け、読取が数十%の率で落ちる (実測)。
+// 動作実績のある旧実装は工場出荷値 250(500µs) のままだった。50µs で妥協
+constexpr uint8_t kReturnDelayRaw = 25;
 constexpr uint16_t kAddrOperatingMode = 11;
 constexpr uint16_t kAddrCurrentLimit = 38;
 constexpr uint16_t kAddrShutdown = 63;
@@ -134,56 +138,98 @@ bool DxlBackend::quarantineActive() const {
 
 // ---------------- 初期化 (§4.1) ----------------
 
-bool DxlBackend::init(cfg::Profile profile) {
-  profile_ = profile;
+namespace {
+// ベンチデバッグ用: ping 失敗時にバス上の応答者を全域探索する
+void scanBusForDebug(DxlWithRxInfo& dxl) {
+  static const uint32_t kBauds[] = {57600, 115200, 1000000, 2000000, 3000000, 4000000};
+  Serial.println("[DXL] bus scan start");
+  for (uint32_t b : kBauds) {
+    dxl.begin(b);
+    for (uint8_t sid = 0; sid <= 5; ++sid) {
+      if (dxl.ping(sid)) {
+        Serial.printf("[DXL] scan: found id=%u baud=%lu model=%d\n", sid,
+                      static_cast<unsigned long>(b), dxl.getModelNumber(sid));
+      }
+    }
+  }
+  Serial.println("[DXL] bus scan done");
+  dxl.begin(cfg::kDxlBaud);  // 設定値へ復帰
+}
+}  // namespace
+
+bool DxlBackend::init() {
   dxl_.begin(cfg::kDxlBaud);
   dxl_.setPortProtocolVersion(cfg::kDxlProtocol);
 
   const uint16_t current_limit_raw =
-      static_cast<uint16_t>(units::currentAToRaw(cfg::currentLimitFor(profile)));
+      static_cast<uint16_t>(units::currentAToRaw(cfg::kCurrentLimitA));
+
+// 各ステップ 3 回リトライ (トルク OFF 中の初期化は再実行安全。実バスは数%の
+// 確率で個々のトランザクションが落ちるため、リトライ無しでは直列 20 ステップ
+// がほぼ確実にどこかで失敗する)。失敗確定時はシリアルへ箇所を出す
+#define DXL_TRY(step, expr)                                    \
+  do {                                                         \
+    bool ok_ = false;                                          \
+    for (int t_ = 0; t_ < 5 && !ok_; ++t_) {                   \
+      ok_ = (expr);                                            \
+      if (!ok_) delay(3);                                      \
+    }                                                          \
+    if (!ok_) {                                                \
+      Serial.printf("[DXL] init fail id=%u: %s\n", id, step);  \
+      return false;                                            \
+    }                                                          \
+  } while (0)
 
   for (uint8_t id : kIds) {
     // ping + Model Number == 1190 検証
-    if (!dxl_.ping(id)) return false;
-    uint8_t mn[2];
-    if (!readRaw(id, kAddrModelNumber, 2, mn)) return false;
-    if (units::le16(mn) != static_cast<int16_t>(cfg::kDxlModelNumber)) return false;
+    if (!dxl_.ping(id)) {
+      scanBusForDebug(dxl_);
+      DXL_TRY("ping", dxl_.ping(id));
+    }
+    {
+      uint8_t mn[2];
+      DXL_TRY("model verify",
+              readRaw(id, kAddrModelNumber, 2, mn) &&
+                  units::le16(mn) == static_cast<int16_t>(cfg::kDxlModelNumber));
+    }
 
     // Torque OFF (EEPROM 書換のため)
-    if (!writeRaw1(id, kAddrTorqueEnable, 0)) return false;
+    DXL_TRY("torque off", writeRaw1(id, kAddrTorqueEnable, 0));
 
     // Operating Mode = 0 (Current Control)
-    if (!writeRaw1(id, kAddrOperatingMode, 0)) return false;
+    DXL_TRY("op mode write", writeRaw1(id, kAddrOperatingMode, 0));
 
     // Current Limit (デフォルト 1750=事実上無制限のため必ず設定)
     {
       const uint8_t d[2] = {static_cast<uint8_t>(current_limit_raw & 0xFF),
                             static_cast<uint8_t>(current_limit_raw >> 8)};
-      if (!verifiedWrite(id, kAddrCurrentLimit, d, 2)) return false;
+      DXL_TRY("current limit write", verifiedWrite(id, kAddrCurrentLimit, d, 2));
     }
 
     // Return Delay Time = 0 / Status Return Level = 2 (配達検証の成立前提)
-    if (!writeRaw1(id, kAddrReturnDelay, 0)) return false;
-    if (!writeRaw1(id, kAddrStatusReturnLevel, 2)) return false;
+    DXL_TRY("return delay write", writeRaw1(id, kAddrReturnDelay, kReturnDelayRaw));
+    DXL_TRY("status level write", writeRaw1(id, kAddrStatusReturnLevel, 2));
 
     // 読み戻し厳密検証 (プロファイル不一致 = FAULT §4.1)
-    if (!verifyByte(id, kAddrOperatingMode, 0)) return false;
-    if (!verifyByte(id, kAddrReturnDelay, 0)) return false;
-    if (!verifyByte(id, kAddrStatusReturnLevel, 2)) return false;
+    DXL_TRY("op mode verify", verifyByte(id, kAddrOperatingMode, 0));
+    DXL_TRY("return delay verify", verifyByte(id, kAddrReturnDelay, kReturnDelayRaw));
+    DXL_TRY("status level verify", verifyByte(id, kAddrStatusReturnLevel, 2));
     {
       uint8_t v[2];
-      if (!readRaw(id, kAddrCurrentLimit, 2, v)) return false;
-      if (units::le16(v) != static_cast<int16_t>(current_limit_raw)) return false;
+      DXL_TRY("current limit verify",
+              readRaw(id, kAddrCurrentLimit, 2, v) &&
+                  units::le16(v) == static_cast<int16_t>(current_limit_raw));
       // PWM Limit(36) は全モード共通の出力上限 → 885(100%) を検証
-      if (!readRaw(id, kAddrPwmLimit, 2, v)) return false;
-      if (units::le16(v) != static_cast<int16_t>(kPwmLimitDefault)) return false;
+      DXL_TRY("pwm limit verify",
+              readRaw(id, kAddrPwmLimit, 2, v) &&
+                  units::le16(v) == static_cast<int16_t>(kPwmLimitDefault));
       // Shutdown(63) は既定値 53 (過熱/過負荷/電圧/ショック保護有効) を要求。
       // 過去に無効化されたまま残っていたら安全既定へ復元して検証する
       uint8_t sd = 0;
-      if (!readRaw(id, kAddrShutdown, 1, &sd)) return false;
+      DXL_TRY("shutdown read", readRaw(id, kAddrShutdown, 1, &sd));
       if (sd != kShutdownDefault) {
-        if (!writeRaw1(id, kAddrShutdown, kShutdownDefault)) return false;
-        if (!verifyByte(id, kAddrShutdown, kShutdownDefault)) return false;
+        DXL_TRY("shutdown write", writeRaw1(id, kAddrShutdown, kShutdownDefault));
+        DXL_TRY("shutdown verify", verifyByte(id, kAddrShutdown, kShutdownDefault));
       }
     }
 
@@ -192,23 +238,24 @@ bool DxlBackend::init(cfg::Profile profile) {
     // した場合は武装(raw=1)のまま残り、以降の初期化トランザクションが 20ms
     // 窓を超えるとトリップするため、非零なら一律 0 (無効) へ落とす
     uint8_t wd = 0;
-    if (!readRaw(id, kAddrBusWatchdog, 1, &wd)) return false;
+    DXL_TRY("watchdog read", readRaw(id, kAddrBusWatchdog, 1, &wd));
     if (wd != 0) {
-      if (!writeRaw1(id, kAddrBusWatchdog, 0)) return false;
+      DXL_TRY("watchdog clear", writeRaw1(id, kAddrBusWatchdog, 0));
     }
 
     // ★Goal Current=0 (モード変更で Current Limit 値へ自動セットされるため必須)
     {
       const uint8_t z[2] = {0, 0};
-      if (!verifiedWrite(id, kAddrGoalCurrent, z, 2)) return false;
+      DXL_TRY("goal zero write", verifiedWrite(id, kAddrGoalCurrent, z, 2));
     }
   }
   // Bus Watchdog 有効化は全サーボの設定完了後にまとめて行う (片側だけ先に
   // 武装すると残りの初期化トランザクションが 20ms 窓を超えた場合に潜在
   // トリップする)。有効化直後から心拍 (零書込) が 5ms 周期で走る前提。
   for (uint8_t id : kIds) {
-    if (!writeRaw1(id, kAddrBusWatchdog, cfg::kBusWatchdogRaw)) return false;
+    DXL_TRY("watchdog arm", writeRaw1(id, kAddrBusWatchdog, cfg::kBusWatchdogRaw));
   }
+#undef DXL_TRY
   // Torque は OFF のまま (Torque ON は enter_balancing() のみ §4.1)
   return true;
 }

--- a/src/hw/dxl_backend.h
+++ b/src/hw/dxl_backend.h
@@ -56,7 +56,7 @@ class DxlBackend {
   explicit DxlBackend(HardwareSerial& serial) : dxl_(serial) {}
 
   // §4.1 初期化シーケンス。失敗時 false (トルク ON しない)。
-  bool init(cfg::Profile profile);
+  bool init();
 
   // ---- 送信ゲート (§4.2 優先順位: 検疫 > save > 心拍 > その他) ----
   void engageQuarantine();               // 検疫開始 (バス全体沈黙)
@@ -101,7 +101,6 @@ class DxlBackend {
   bool watchdogRecoverOne(uint8_t id);
 
   DxlWithRxInfo dxl_;
-  cfg::Profile profile_ = cfg::Profile::Bringup;
   volatile int64_t quarantine_until_us_ = 0;
   bool save_gate_ = false;
   uint8_t health_phase_ = 0;

--- a/src/hw/param_store.cpp
+++ b/src/hw/param_store.cpp
@@ -6,7 +6,6 @@ namespace hw {
 namespace {
 constexpr const char* kNs = "bslbal";
 constexpr const char* kKeyParams = "tparams";
-constexpr const char* kKeyCommission = "commrec";
 }  // namespace
 
 bool ParamStore::loadParams(core::TuningParams* out) {
@@ -21,30 +20,11 @@ bool ParamStore::loadParams(core::TuningParams* out) {
   return true;
 }
 
-bool ParamStore::loadCommissioning(core::CommissioningRecord* out) {
-  Preferences prefs;
-  if (!prefs.begin(kNs, /*readOnly=*/true)) return false;
-  core::CommissioningRecord rec;
-  const size_t n = prefs.getBytes(kKeyCommission, &rec, sizeof(rec));
-  prefs.end();
-  if (n != sizeof(rec)) return false;
-  *out = rec;  // 検証 (validateCommissioning) は呼び出し側で現行値と照合
-  return true;
-}
-
 bool ParamStore::saveParams(const core::TuningParams& rec) {
   if (!core::validateParams(rec)) return false;
   Preferences prefs;
   if (!prefs.begin(kNs, /*readOnly=*/false)) return false;
   const size_t n = prefs.putBytes(kKeyParams, &rec, sizeof(rec));
-  prefs.end();
-  return n == sizeof(rec);
-}
-
-bool ParamStore::saveCommissioning(const core::CommissioningRecord& rec) {
-  Preferences prefs;
-  if (!prefs.begin(kNs, /*readOnly=*/false)) return false;
-  const size_t n = prefs.putBytes(kKeyCommission, &rec, sizeof(rec));
   prefs.end();
   return n == sizeof(rec);
 }

--- a/src/hw/param_store.h
+++ b/src/hw/param_store.h
@@ -10,11 +10,9 @@ class ParamStore {
  public:
   // 読込 (INITIALIZING 内・Torque ON 前)。無効レコードは既定値のまま false。
   static bool loadParams(core::TuningParams* out);
-  static bool loadCommissioning(core::CommissioningRecord* out);
 
   // 書込 (検証済み safe-off 下でのみ呼ぶこと — 呼び出し側の責務)
   static bool saveParams(const core::TuningParams& rec);
-  static bool saveCommissioning(const core::CommissioningRecord& rec);
 };
 
 }  // namespace hw

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,29 +57,24 @@ void setup() {
   core::TuningParams params;  // 既定値で初期化済み
   hw::ParamStore::loadParams(&params);
 
-  core::CommissioningRecord comm;
-  bool commissioned = false;
-  if (hw::ParamStore::loadCommissioning(&comm)) {
-    commissioned = core::validateCommissioning(
-        comm, core::currentSignAxisChecksum(), /*current_calib_version=*/1);
-  }
-  const cfg::Profile profile =
-      commissioned ? cfg::Profile::Normal : cfg::Profile::Bringup;
-
   // HW 初期化 (IMU / DXL §4.1)。互いに独立して実行する — IMU が死んでいても
   // DXL 初期化 (前回稼働の残留トルクの解除経路) は必ず走らせる。
   // 失敗時もタスクは起動し FSM が FAULT を表示する。
   const bool imu_ok = imu_backend.init();
   DXL_SERIAL.begin(cfg::kDxlBaud, SERIAL_8N1, cfg::kPinRxServo, cfg::kPinTxServo);
-  const bool dxl_ok = dxl_backend.init(profile);
+  // バースト的なバス不調 (実測) に備えて初期化シーケンス全体も再試行する
+  bool dxl_ok = false;
+  for (int attempt = 0; attempt < 3 && !dxl_ok; ++attempt) {
+    if (attempt > 0) delay(50);
+    dxl_ok = dxl_backend.init();
+  }
   const bool init_ok = imu_ok && dxl_ok;
+  Serial.printf("[BOOT] imu_ok=%d dxl_ok=%d\n", imu_ok, dxl_ok);
 
   control_ctx.imu = &imu_backend;
   control_ctx.dxl = &dxl_backend;
   control_ctx.shared = &shared_state;
   control_ctx.params = params;
-  control_ctx.commissioned = commissioned;
-  control_ctx.profile = profile;
   control_ctx.init_ok = init_ok;
 
   ui_ctx.shared = &shared_state;

--- a/src/shared/shared_state.h
+++ b/src/shared/shared_state.h
@@ -16,8 +16,6 @@ struct Snapshot {
   // 状態
   uint8_t fsm_state = 0;        // core::FsmState
   uint8_t fault_reason = 0;     // core::FaultReason
-  bool commissioned = false;
-  uint8_t profile = 0;          // cfg::Profile
   // 制御量 (SI)
   float theta = 0.0f;           // 0 中心 [rad]
   float theta_rate = 0.0f;      // [rad/s]
@@ -29,6 +27,7 @@ struct Snapshot {
   float i_cmd_right = 0.0f;
   float i_present_left = 0.0f;
   float i_present_right = 0.0f;
+  bool wheel_valid = false;     // DXL 帰還の有効性 (起立検出の必要条件)
   // タイミング
   float dt_last = 0.0f;         // [s]
   float dt_max = 0.0f;
@@ -51,7 +50,7 @@ struct ParamCommand {
   float value;
 };
 
-enum class SaveKind : uint8_t { None = 0, Params, Commission };
+enum class SaveKind : uint8_t { None = 0, Params };
 
 class SharedState {
  public:

--- a/src/tasks/control_task.cpp
+++ b/src/tasks/control_task.cpp
@@ -38,7 +38,6 @@ struct LoopState {
   core::SafetyFsm fsm;
   PlausibilityMonitor plaus_l, plaus_r;
   core::TuningParams params;
-  cfg::Profile profile = cfg::Profile::Bringup;
 
   int64_t prev_us = 0;
   float dt_max = 0.0f;
@@ -70,9 +69,9 @@ void applyBalanceParams(LoopState& ls) {
   bp.wheel_speed_soft = cfg::kWheelSpeedSoftRadS;
   bp.wheel_speed_hard = cfg::kWheelSpeedHardRadS;
   bp.slew_a_per_s = cfg::kCurrentSlewAPerS;
-  // ソフト上限はプロファイルの EEPROM Current Limit を超えない (超過指令は
+  // ソフト上限は EEPROM Current Limit を超えない (超過指令は
   // XL330 が範囲外エラーを返し verified_write が失敗するため §2.3)
-  const float eeprom_limit = cfg::currentLimitFor(ls.profile);
+  const float eeprom_limit = cfg::kCurrentLimitA;
   bp.i2t.i_peak = std::fmin(cfg::kCurrentPeakA, eeprom_limit);
   bp.i2t.i_cont = std::fmin(cfg::kCurrentContA, bp.i2t.i_peak);
   bp.i2t.peak_duration_s = cfg::kPeakDurationS;
@@ -127,7 +126,6 @@ void controlTaskEntry(void* pvParameters) {
   ControlContext& ctx = *static_cast<ControlContext*>(pvParameters);
   LoopState ls;
   ls.params = ctx.params;
-  ls.profile = ctx.profile;
 
   // 推定器・制御器・FSM の初期化
   core::AttitudeEstimator::Params ep;
@@ -145,8 +143,6 @@ void controlTaskEntry(void* pvParameters) {
   fp.fall_threshold_rad = cfg::kFallThresholdRad;
   fp.fall_escalation_count = cfg::kFallEscalationCount;
   fp.fall_escalation_window_s = cfg::kFallEscalationWindowS;
-  fp.commissioned = ctx.commissioned;
-  fp.auto_arm = cfg::kAutoArmOnBootDefault;
   ls.fsm.setParams(fp);
 
   if (ctx.init_ok) {
@@ -401,8 +397,6 @@ void controlTaskEntry(void* pvParameters) {
     shared::Snapshot sn;
     sn.fsm_state = static_cast<uint8_t>(ls.fsm.state());
     sn.fault_reason = static_cast<uint8_t>(ls.fsm.faultReason());
-    sn.commissioned = ctx.commissioned;
-    sn.profile = static_cast<uint8_t>(ctx.profile);
     sn.theta = theta;
     sn.theta_rate = theta_rate;
     sn.theta_ref = out.theta_ref;
@@ -413,6 +407,7 @@ void controlTaskEntry(void* pvParameters) {
     sn.i_cmd_right = ls.last_cmd_r;
     sn.i_present_left = fb.i_left;
     sn.i_present_right = fb.i_right;
+    sn.wheel_valid = fb.valid;
     sn.dt_last = dt;
     sn.dt_max = ls.dt_max;
     sn.loop_count = ls.loop_count;

--- a/src/tasks/control_task.h
+++ b/src/tasks/control_task.h
@@ -17,8 +17,6 @@ struct ControlContext {
   hw::DxlBackend* dxl;
   shared::SharedState* shared;
   core::TuningParams params;   // 起動時ロード済み (検証通過 or 既定値)
-  bool commissioned;
-  cfg::Profile profile;
   bool init_ok;                // main での HW 初期化結果 (false → 即 FAULT)
 };
 

--- a/src/tasks/ui_task.cpp
+++ b/src/tasks/ui_task.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 
 #include "../app_config.h"
-#include "../core/param_validation.h"
 #include "../core/safety_fsm.h"
 #include "../core/units.h"
 #include "../hw/param_store.h"
@@ -15,6 +14,16 @@ namespace {
 using core::FsmState;
 
 constexpr float kRadToDeg = 180.0f / units::kPi;
+
+// シリアルデバッグ用フォールト名 (core::FaultReason と同順)
+const char* faultName(uint8_t f) {
+  static const char* kNames[] = {
+      "None", "InitFailed", "ImuStale", "DxlReadStale", "DxlWriteUnverified",
+      "WdTripTorqueOn", "WdRecoverRepeated", "HardOverspeed", "HwErrorStatus",
+      "OverTemp", "UnderVoltage", "LoopOverrun", "CurrentPlausibility",
+      "FallEscalation", "EntryVerifyFailed"};
+  return f < sizeof(kNames) / sizeof(kNames[0]) ? kNames[f] : "?";
+}
 
 const char* stateName(uint8_t s) {
   switch (static_cast<FsmState>(s)) {
@@ -45,10 +54,9 @@ struct PanelState {
 
 void drawPanel(const shared::Snapshot& sn) {
   M5.Display.setCursor(10, 8);
-  M5.Display.printf("%s %s prof:%s dt:%.1fms ",
+  M5.Display.printf("%s %s dt:%.1fms ",
                     stateName(sn.fsm_state),
                     sn.fault_reason ? "FLT" : "   ",
-                    sn.profile == 1 ? "NRM" : "BUP",
                     sn.dt_max * 1000.0f);
   drawRow("Eq[deg]", 30, sn.params.pitch_eq * kRadToDeg, 1);
   drawRow("Kp", 70, sn.params.kp, 2);
@@ -57,11 +65,9 @@ void drawPanel(const shared::Snapshot& sn) {
   M5.Display.setCursor(10, 190);
   M5.Display.printf("th:%+5.1f V:%4.1f Bat:%d%% ", sn.theta * kRadToDeg,
                     sn.voltage, M5.Power.getBatteryLevel());
-  // 保存/コミッショニング (torque OFF 状態でのみ有効 §9.1)
+  // 保存 (torque OFF 状態でのみ有効 §9.1)
   M5.Display.drawRect(20, 210, 110, 28, WHITE);
   M5.Display.drawString("SAVE", 50, 216, 2);
-  M5.Display.drawRect(180, 210, 110, 28, WHITE);
-  M5.Display.drawString("COMISN", 200, 216, 2);
 }
 
 void handleTouch(const shared::Snapshot& sn, shared::SharedState& sh,
@@ -100,10 +106,6 @@ void handleTouch(const shared::Snapshot& sn, shared::SharedState& sh,
     if (x >= 20 && x < 130 && torque_off) {
       ps.pending_save = shared::SaveKind::Params;
       sh.requestSave(shared::SaveKind::Params);
-    } else if (x >= 180 && x < 290 && torque_off) {
-      // 符号試験 (§7) 合格のユーザ明示確認 = コミッショニング (次回起動から有効)
-      ps.pending_save = shared::SaveKind::Commission;
-      sh.requestSave(shared::SaveKind::Commission);
     } else if (!torque_off) {
       M5.Display.setCursor(10, 190);
       M5.Display.print("STOP first (BtnC hold)   ");
@@ -116,14 +118,6 @@ void performSave(const shared::Snapshot& sn, shared::SharedState& sh,
                  PanelState& ps) {
   if (ps.pending_save == shared::SaveKind::Params) {
     hw::ParamStore::saveParams(sn.params);
-  } else if (ps.pending_save == shared::SaveKind::Commission) {
-    core::CommissioningRecord rec;
-    rec.schema_version = cfg::kCommissionSchemaVersion;
-    rec.profile = static_cast<uint8_t>(cfg::Profile::Normal);
-    rec.sign_axis_checksum = core::currentSignAxisChecksum();
-    rec.calib_version = 1;
-    rec.user_confirmed = true;
-    hw::ParamStore::saveCommissioning(rec);
   }
   ps.pending_save = shared::SaveKind::None;
   sh.setSaveDone();
@@ -175,6 +169,24 @@ void uiTaskEntry(void* pvParameters) {
       } else {
         M5.Display.clear();
         ctx.avatar->resume();
+      }
+    }
+
+    // 1Hz シリアル状態出力 (ベンチデバッグ用)
+    {
+      static uint32_t last_dbg_ms = 0;
+      const uint32_t now_ms = millis();
+      if (have_snapshot && now_ms - last_dbg_ms >= 1000) {
+        last_dbg_ms = now_ms;
+        Serial.printf(
+            "[ST] %s flt=%s th=%+6.1f thr=%+6.2f wv=%d wL=%+6.1f wR=%+6.1f "
+            "iL=%+.2f/%+.2f iR=%+.2f/%+.2f V=%.1f T=%.0f dt=%.1f/%.1fms n=%lu\n",
+            stateName(sn.fsm_state), faultName(sn.fault_reason),
+            sn.theta * kRadToDeg, sn.theta_rate, sn.wheel_valid ? 1 : 0,
+            sn.omega_left, sn.omega_right, sn.i_cmd_left, sn.i_present_left,
+            sn.i_cmd_right, sn.i_present_right, sn.voltage, sn.temperature,
+            sn.dt_last * 1000.0f, sn.dt_max * 1000.0f,
+            static_cast<unsigned long>(sn.loop_count));
       }
     }
 

--- a/test/test_core/test_main.cpp
+++ b/test/test_core/test_main.cpp
@@ -314,7 +314,7 @@ static void test_balance_stale_freezes_outer_loop() {
 
 // ---------------- FSM (§6) ----------------
 
-static SafetyFsm::Params fsmParams(bool commissioned = true, bool auto_arm = true) {
+static SafetyFsm::Params fsmParams() {
   SafetyFsm::Params p;
   p.start_window_rad = 0.0873f;
   p.start_rate_max = 0.35f;
@@ -323,8 +323,6 @@ static SafetyFsm::Params fsmParams(bool commissioned = true, bool auto_arm = tru
   p.fall_threshold_rad = 0.611f;
   p.fall_escalation_count = 3;
   p.fall_escalation_window_s = 30.0f;
-  p.auto_arm = auto_arm;
-  p.commissioned = commissioned;
   return p;
 }
 
@@ -352,15 +350,11 @@ static bool driveUntilArm(SafetyFsm& fsm, float* now_s, float duration_s) {
 }
 
 static void test_fsm_boot_gate() {
+  // notifyInitDone() は常に Idle へ (自動アーム。コミッショニング機構は廃止)
   SafetyFsm fsm;
-  fsm.setParams(fsmParams(true, true));
+  fsm.setParams(fsmParams());
   fsm.notifyInitDone();
   TEST_ASSERT_EQUAL(static_cast<int>(FsmState::Idle), static_cast<int>(fsm.state()));
-
-  SafetyFsm fsm2;
-  fsm2.setParams(fsmParams(false, true));  // 未コミッショニング → 明示アーム必須
-  fsm2.notifyInitDone();
-  TEST_ASSERT_EQUAL(static_cast<int>(FsmState::Disarmed), static_cast<int>(fsm2.state()));
 }
 
 static void test_fsm_arm_sequence() {
@@ -589,41 +583,6 @@ static void test_params_reject_invalid() {
   TEST_ASSERT_FALSE(validateParams(rec));
 }
 
-static void test_commissioning_fail_closed() {
-  const uint32_t csum = currentSignAxisChecksum();
-  CommissioningRecord rec;
-  rec.schema_version = cfg::kCommissionSchemaVersion;
-  rec.profile = static_cast<uint8_t>(cfg::Profile::Normal);
-  rec.sign_axis_checksum = csum;
-  rec.calib_version = 3;
-  rec.user_confirmed = true;
-  TEST_ASSERT_TRUE(validateCommissioning(rec, csum, 3));
-
-  // 車輪符号が変わった (チェックサム不一致) → 未コミッショニング扱い
-  const uint32_t csum_wheel = signAxisChecksum(
-      -cfg::kSignLeft, cfg::kSignRight, cfg::kImuAccTiltSign,
-      cfg::kImuAccVertSign, cfg::kImuGyroSign);
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum_wheel, 3));
-  // IMU 軸符号が変わっても無効化される (gate2 P2 回帰)
-  const uint32_t csum_imu = signAxisChecksum(
-      cfg::kSignLeft, cfg::kSignRight, -cfg::kImuAccTiltSign,
-      cfg::kImuAccVertSign, cfg::kImuGyroSign);
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum_imu, 3));
-  // 校正版が進んだ
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum, 4));
-  // 未確認フラグ
-  rec.user_confirmed = false;
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum, 3));
-  // 旧スキーマ
-  rec.user_confirmed = true;
-  rec.schema_version = 0;
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum, 3));
-  // Bringup プロファイルの記録では auto-arm 不可
-  rec.schema_version = cfg::kCommissionSchemaVersion;
-  rec.profile = static_cast<uint8_t>(cfg::Profile::Bringup);
-  TEST_ASSERT_FALSE(validateCommissioning(rec, csum, 3));
-}
-
 // ---------------- runner ----------------
 
 int main(int, char**) {
@@ -658,7 +617,6 @@ int main(int, char**) {
   RUN_TEST(test_fsm_fault_latch);
   RUN_TEST(test_params_reject_invalid);
   RUN_TEST(test_params_defaults_valid);
-  RUN_TEST(test_commissioning_fail_closed);
   RUN_TEST(test_fsm_entry_failed);
   return UNITY_END();
 }


### PR DESCRIPTION
## 概要

実機ベンチ検証で電流制御モードPID倒立の初動作を確認し、その過程で判明した問題を修正。あわせてユーザ判断によりコミッショニング機構を削除した。

**実機で BALANCE 遷移・倒立トルク動作を確認済み**（振動が大きくゲイン調整は要るが、これは別件のWiFiテレメトリ環境で実施予定）。

## 変更内容

### 1. コミッショニング機構の削除（-181行）
- DISARMED起動ゲート / COMISNボタン / CommissioningRecord のNVS保存・検証 / Bringup・Normal 2プロファイルを全削除
- 起動時は常にIDLEへ自動アーム、XL330電流上限は0.9A固定（旧Normal値）

### 2. 実機で判明した問題の修正
| 問題 | 修正 |
|---|---|
| DXL全サーボping無応答 | RX=33/TX=32・1Mbaudへ復元（masterの動作実績構成。`for_arduino_ide/`の2M・ピン逆転は旧世代の遺物） |
| 読取が数十%の率で失敗 | Return Delay Time 0→50µs（RDT=0は片線ハーフデュプレクスのターンアラウンドで応答先頭が化ける・実測） |
| 初期化がブート毎にランダム箇所で失敗 | 実バスは単発数%+バースト(>15ms)のロスあり。ステップ毎5回+シーケンス全体3回リトライで4/4ブート安定 |
| 起動直後のDxlReadStale即FAULT | 閾値20ms→200ms（失敗周期はコースト§4.2のため安全性維持） |
| IDLE→BALANCEが数秒滞る | 起立検出タイマが単発読取落ちでリセットされる実測バグを修正（欠落周期は情報なし扱い）。保持1.0s→0.5s |

### 3. ベンチデバッグ計装（シリアル115200）
- `[BOOT]` IMU/DXL初期化結果、`[DXL]` 初期化失敗箇所+全ボーレート×IDバススキャン、`[ST]` 1Hz状態出力（FSM状態/θ/車輪/電流/電圧/dt）

## 検証
- `pio test -e native`: 31/31 PASS
- 実機: 4/4ブートで初期化成功→IDLE安定（200Hz、dt=5.0ms維持）、起立→BALANCE遷移・倒立動作を確認

## 備考
- 安全機構（Bus Watchdog・検証付き書込・転倒検出・FAULT体系）は不変
- 起立検出の読取欠落許容は、帰還恒久喪失時にDxlReadStale FAULT(200ms)が先に働くため安全側を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)